### PR TITLE
More thread-friendly compilation API method

### DIFF
--- a/benchmark/benchmark.jl
+++ b/benchmark/benchmark.jl
@@ -30,23 +30,26 @@ function grad_benchmark_driver!(out, f, x)
     gc()
 
     if length(tp.tape) <= 10000
-        ctp = ReverseDiff.compile(tp)
+        @eval begin
+            out, x = $out, $x
+            ctp = ReverseDiff.compile($tp)
 
-        # warmup
-        ReverseDiff.gradient!(out, ctp, x)
-        ReverseDiff.forward_pass!(ctp)
-        ReverseDiff.reverse_pass!(ctp)
+            # warmup
+            ReverseDiff.gradient!(out, ctp, x)
+            ReverseDiff.forward_pass!(ctp)
+            ReverseDiff.reverse_pass!(ctp)
 
-        # actual
-        print("  gradient! (compiled): ")
-        @time ReverseDiff.gradient!(out, ctp, x)
-        gc()
-        print("  forward pass (compiled): ")
-        @time ReverseDiff.forward_pass!(ctp)
-        gc()
-        print("  reverse pass (compiled): ")
-        @time ReverseDiff.reverse_pass!(ctp)
-        gc()
+            # actual
+            print("  gradient! (compiled): ")
+            @time ReverseDiff.gradient!(out, ctp, x)
+            gc()
+            print("  forward pass (compiled): ")
+            @time ReverseDiff.forward_pass!(ctp)
+            gc()
+            print("  reverse pass (compiled): ")
+            @time ReverseDiff.reverse_pass!(ctp)
+            gc()
+        end
     else
         println("skipping compiled GradientTape benchmark because the tape is too long ($(length(tp.tape)) elements)")
     end

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -9,7 +9,6 @@ CurrentModule = ReverseDiff
 ```@docs
 ReverseDiff.gradient
 ReverseDiff.gradient!
-ReverseDiff.compile_gradient
 ```
 
 ## Jacobians of `f(x::AbstractArray{<:Real}...)::AbstractArray{<:Real}`
@@ -17,7 +16,6 @@ ReverseDiff.compile_gradient
 ```@docs
 ReverseDiff.jacobian
 ReverseDiff.jacobian!
-ReverseDiff.compile_jacobian
 ```
 
 ## Hessians of `f(x::AbstractArray{<:Real})::Real`
@@ -25,7 +23,6 @@ ReverseDiff.compile_jacobian
 ```@docs
 ReverseDiff.hessian
 ReverseDiff.hessian!
-ReverseDiff.compile_hessian
 ```
 
 ## The `AbstractTape` API

--- a/src/api/gradients.jl
+++ b/src/api/gradients.jl
@@ -20,7 +20,7 @@ call.
 """
 function gradient(f, input, cfg::GradientConfig = GradientConfig(input))
     tape = GradientTape(f, input, cfg)
-    result = construct_result(tape.input)
+    result = construct_result(input_hook(tape))
     seeded_reverse_pass!(result, tape)
     empty!(cfg.tape)
     return result
@@ -59,7 +59,7 @@ If `input` is a tuple of `AbstractArray`s, assume `tape` represents a function o
 of `f` w.r.t. `input[i].`
 """
 function gradient!(tape::Union{GradientTape,CompiledGradient}, input)
-    result = construct_result(tape.input)
+    result = construct_result(input_hook(tape))
     gradient!(result, tape, input)
     return result
 end

--- a/src/api/hessians.jl
+++ b/src/api/hessians.jl
@@ -67,7 +67,7 @@ Assuming `tape` represents a function of the form `f(::AbstractArray{<:Real})::R
 return the Hessian `H(f)(input)`.
 """
 function hessian!(tape::Union{HessianTape,CompiledHessian}, input::AbstractArray)
-    result = construct_result(tape.output, tape.input)
+    result = construct_result(output_hook(tape), input_hook(tape))
     hessian!(result, tape, input)
     return result
 end

--- a/src/api/hessians.jl
+++ b/src/api/hessians.jl
@@ -92,7 +92,7 @@ end
 function hessian!(result::DiffResult, tape::Union{HessianTape,CompiledHessian}, input::AbstractArray)
     seeded_forward_pass!(tape, input)
     seeded_reverse_pass!(DiffResult(DiffBase.gradient(result), DiffBase.hessian(result)), tape)
-    DiffBase.value!(result, tape.func(input))
+    DiffBase.value!(result, func_hook(tape)(input))
     return result
 end
 

--- a/src/api/jacobians.jl
+++ b/src/api/jacobians.jl
@@ -60,7 +60,7 @@ function jacobian(f!, output, input, cfg::JacobianConfig = JacobianConfig(output
     tape = JacobianTape(f!, output, input, cfg)
     isa(input, TrackedArray) && empty!(input.tape)
     result = jacobian!(tape, input)
-    extract_result_value!(output, tape.output)
+    extract_result_value!(output, output_hook(tape))
     empty!(tape.tape)
     return result
 end
@@ -75,7 +75,7 @@ function jacobian!(result, f!, output, input, cfg::JacobianConfig = JacobianConf
     tape = JacobianTape(f!, output, input, cfg)
     isa(input, TrackedArray) && empty!(input.tape)
     jacobian!(result, tape, input)
-    extract_result_value!(output, tape.output)
+    extract_result_value!(output, output_hook(tape))
     empty!(tape.tape)
     return result
 end
@@ -102,7 +102,7 @@ execute `tape` with new `input` values. There is no way to re-run `tape`'s tape 
 new `output` values into the tape.
 """
 function jacobian!(tape::Union{JacobianTape,CompiledJacobian}, input)
-    result = construct_result(tape.output, tape.input)
+    result = construct_result(output_hook(tape), input_hook(tape))
     jacobian!(result, tape, input)
     return result
 end
@@ -138,32 +138,32 @@ differentation.
 
 # function jacobian(f, input, cfg::JacobianConfig = JacobianConfig(input))
 #     tape = JacobianTape(f, input, cfg)
-#     result = construct_result(tape.output, tape.input)
-#     seeded_reverse_pass!(result, tape.output, tape.input, tape.tape)
+#     result = construct_result(output_hook(tape), input_hook(tape))
+#     seeded_reverse_pass!(result, output_hook(tape), input_hook(tape), tape.tape)
 #     empty!(tape.tape)
 #     return result
 # end
 #
 # function jacobian!(result, f, input, cfg::JacobianConfig = JacobianConfig(input))
 #     tape = JacobianTape(f, input, cfg)
-#     seeded_reverse_pass!(result, tape.output, tape.input, tape.tape)
+#     seeded_reverse_pass!(result, output_hook(tape), input_hook(tape), tape.tape)
 #     empty!(tape.tape)
 #     return result
 # end
 #
 # function jacobian(f!, output, input, cfg::JacobianConfig = JacobianConfig(output, input))
 #     tape = JacobianTape(f!, output, input, cfg)
-#     result = construct_result(tape.output, tape.input)
-#     seeded_reverse_pass!(result, tape.output, tape.input, tape.tape)
-#     extract_result_value!(output, tape.output)
+#     result = construct_result(output_hook(tape), input_hook(tape))
+#     seeded_reverse_pass!(result, output_hook(tape), input_hook(tape), tape.tape)
+#     extract_result_value!(output, output_hook(tape))
 #     empty!(tape.tape)
 #     return result
 # end
 #
 # function jacobian!(result, f!, output, input, cfg::JacobianConfig = JacobianConfig(output, input))
 #     tape = JacobianTape(f!, output, input, cfg)
-#     seeded_reverse_pass!(result, tape.output, tape.input, tape.tape)
-#     extract_result_value!(output, tape.output)
+#     seeded_reverse_pass!(result, output_hook(tape), input_hook(tape), tape.tape)
+#     extract_result_value!(output, output_hook(tape))
 #     empty!(tape.tape)
 #     return result
 # end

--- a/src/api/tape.jl
+++ b/src/api/tape.jl
@@ -22,127 +22,103 @@ for T in (:GradientTape, :JacobianTape, :HessianTape)
 
         # "private" convienence constructor
         $(_T){F,I,O}(func::F, input::I, output::O, tape::RawTape) = $(T){F,I,O}(func, input, output, tape)
+
+        Base.length(t::$T) = length(t.tape)
+
+        input_hook(t::$T) = t.input
+
+        output_hook(t::$T) = t.output
+
+        forward_pass!(t::$T) = forward_pass!(t.tape)
+
+        reverse_pass!(t::$T) = reverse_pass!(t.tape)
     end
 end
 
-Base.length(t::AbstractTape) = length(t.tape)
-
-forward_pass!(t::AbstractTape) = forward_pass!(t.tape)
-
-reverse_pass!(t::AbstractTape) = reverse_pass!(t.tape)
-
 function seeded_forward_pass!(t::AbstractTape, input)
-    value!(t.input, input)
+    value!(input_hook(t), input)
     forward_pass!(t)
     return nothing
 end
 
 function seeded_reverse_pass!(result, t::AbstractTape)
-    seeded_reverse_pass!(result, t.output, t.input, t)
+    seeded_reverse_pass!(result, output_hook(t), input_hook(t), t)
     return result
 end
 
-############
-# Compiled #
-############
+################
+# CompiledTape #
+################
 
-immutable Compiled{T<:AbstractTape,F,I,O,FP,RP} <: AbstractTape
-    record_type::Type{T}
-    func::F
-    input::I
-    output::O
-    forward_pass!::FP
-    reverse_pass!::RP
+immutable CompiledTape{S,T<:AbstractTape} <: AbstractTape
+    tape::T
 end
 
-typealias CompiledGradient{T<:GradientTape,F,I,O,FP,RP} Compiled{T,F,I,O,FP,RP}
-typealias CompiledJacobian{T<:JacobianTape,F,I,O,FP,RP} Compiled{T,F,I,O,FP,RP}
-typealias CompiledHessian{T<:HessianTape,F,I,O,FP,RP}   Compiled{T,F,I,O,FP,RP}
+(::Type{CompiledTape{S}}{S,T<:AbstractTape}(t::T) = CompiledTape{S,T}(t)
 
-forward_pass!(ct::Compiled) = ct.forward_pass!()
+typealias CompiledGradient{S,T<:GradientTape} CompiledTape{S,T}
+typealias CompiledJacobian{S,T<:JacobianTape} CompiledTape{S,T}
+typealias CompiledHessian{S,T<:HessianTape}   CompiledTape{S,T}
 
-reverse_pass!(ct::Compiled) = ct.reverse_pass!()
+Base.length(ct::CompiledTape) = length(ct.tape)
+
+input_hook(ct::CompiledTape) = input_hook(ct.tape)
+
+output_hook(ct::CompiledTape) = output_hook(ct.tape)
 
 """
     ReverseDiff.compile(t::AbstractTape)
 
-Return a fully compiled representation of `t`. The type of this representation will be
-`CompiledGradient`/`CompiledJacobian`/`CompiledHessian`, depending on the type of `t`. This
-object can be passed to any API methods that accept `t`.
+Return a fully compiled representation of `t` of type `CompiledTape`. This object can be
+passed to any API methods that accept `t` (e.g. `gradient!(result, t, input)`).
 
 In many cases, compiling `t` can significantly speed up execution time. Note that the longer
 the tape, the more time compilation may take. Very long tapes (i.e. when `length(t)` is on
 the order of 10000 elements) can take a very long time to compile.
 
 Note that this function calls `eval` in the `current_module()` to generate functions
-from `t`. Thus, the returned `Compiled*` type will only be useable once the world-age
+from `t`. Thus, the returned `CompiledTape` will only be useable once the world-age
 counter has caught up with the world-age of the `eval`'d functions (i.e. once the call
 stack has bubbled up to top level).
 """
 function compile(t::AbstractTape)
-    return Compiled(typeof(t), t.func, t.input, t.output,
-                    eval(current_module(), :(() -> $(generate_forward_code(t.tape)))),
-                    eval(current_module(), :(() -> $(generate_reverse_code(t.tape)))))
+    ct = CompiledTape{gensym()}(t)
+    compile(ct)
+    return ct
 end
 
-"""
-    ReverseDiff.compile_gradient(f, args...)
+function compile(ct::CompiledTape)
+    eval(ReverseDiff, generate_forward_pass_method(typeof(ct), ct.tape))
+    eval(ReverseDiff, generate_reverse_pass_method(typeof(ct), ct.tape))
+    return ct
+end
 
-Return a function equivalent to `(result, input) -> gradient!(result, f, input)`.
-`ReverseDiff.compile_gradient` will record and compile a `GradientTape` for `f`, which
-will generally make the returned function far more efficient than naively calling
-`gradient!(result, f, input)`.
-
-The arguments to `ReverseDiff.compile_gradient` are the same as the arguments to
-`GradientTape`; see `ReverseDiff.GradientTape` documentation for details.
-
-The usage restrictions on the returned function are the same as the usage restrictions
-for calling `gradient!(result, tape, input)` where `tape` is a compiled `GradientTape`;
-see `ReverseDiff.compile` for details (including an important note on world-age).
-"""
 function compile_gradient(f, args...)
+    Base.depwarn("`ReverseDiff.compile_gradient(f, args...)` is deprecated" *
+                 ", use `ReverseDiff.compile(ReverseDiff.GradientTape(f, args...))`"*
+                 "instead. Then, you can execute the returned CompiledTape `t` by calling"*
+                 " `ReverseDiff.gradient!(result, t, input)`.",
+                 :compile_gradient)
     tape = compile(GradientTape(f, args...))
     return (result, input) -> gradient!(result, tape, input)
 end
 
-"""
-    ReverseDiff.compile_jacobian(f, args...)
-
-Return a function equivalent to `(result, input) -> jacobian!(result, f, input)`.
-`ReverseDiff.compile_jacobian` will record and compile a `JacobianTape` for `f`, which
-will generally make the returned function far more efficient than naively calling
-`jacobian!(result, f, input)`.
-
-The arguments to `ReverseDiff.compile_jacobian` are the same as the arguments to
-`JacobianTape`; see `ReverseDiff.JacobianTape` documentation for details. Note that
-this means `ReverseDiff.compile_jacobian` also supports target functions of the form
-`f!(output, input)`.
-
-The usage restrictions on the returned function are the same as the usage restrictions
-for calling `jacobian!(result, tape, input)` where `tape` is a compiled `JacobianTape`;
-see `ReverseDiff.compile` for details (including an important note on world-age).
-"""
 function compile_jacobian(f, args...)
+    Base.depwarn("`ReverseDiff.compile_jacobian(f, args...)` is deprecated" *
+                 ", use `ReverseDiff.compile(ReverseDiff.JacobianTape(f, args...))`"*
+                 "instead. Then, you can execute the returned CompiledTape `t` by calling"*
+                 " `ReverseDiff.jacobian!(result, t, input)`.",
+                 :compile_jacobian)
     tape = compile(JacobianTape(f, args...))
     return (result, input) -> jacobian!(result, tape, input)
 end
 
-"""
-    ReverseDiff.compile_hessian(f, args...)
-
-Return a function equivalent to `(result, input) -> hessian!(result, f, input)`.
-`ReverseDiff.compile_hessian` will record and compile a `HessianTape` for `f`, which
-will generally make the returned function far more efficient than naively calling
-`hessian!(result, f, input)`.
-
-The arguments to `ReverseDiff.compile_hessian` are the same as the arguments to
-`HessianTape`; see `ReverseDiff.HessianTape` documentation for details.
-
-The usage restrictions on the returned function are the same as the usage restrictions
-for calling `hessian!(result, tape, input)` where `tape` is a compiled `HessianTape`;
-see `ReverseDiff.compile` for details (including an important note on world-age).
-"""
 function compile_hessian(f, args...)
+    Base.depwarn("`ReverseDiff.compile_hessian(f, args...)` is deprecated" *
+                 ", use `ReverseDiff.compile(ReverseDiff.HessianTape(f, args...))`"*
+                 "instead. Then, you can execute the returned CompiledTape `t` by calling"*
+                 " `ReverseDiff.hessian!(result, t, input)`.",
+                 :compile_hessian)
     tape = compile(HessianTape(f, args...))
     return (result, input) -> hessian!(result, tape, input)
 end

--- a/src/tape.jl
+++ b/src/tape.jl
@@ -73,28 +73,6 @@ end
 @noinline reverse_exec!(instruction::ScalarInstruction) = scalar_reverse_exec!(instruction)
 @noinline reverse_exec!(instruction::SpecialInstruction) = special_reverse_exec!(instruction)
 
-####################
-# pass compilation #
-####################
-
-function generate_forward_pass_method{T}(::Type{T}, tape::RawTape)
-    body = Expr(:block)
-    for i in 1:length(tape)
-        push!(body.args, :(ReverseDiff.forward_exec!(tape[$i]::$(typeof(tape[i])))))
-    end
-    push!(body.args, :(return nothing))
-    return :(ReverseDiff.forward_pass!(tape::$T) = $body)
-end
-
-function generate_reverse_pass_method{T}(::Type{T}, tape::RawTape)
-    body = Expr(:block)
-    for i in length(tape):-1:1
-        push!(body.args, :(ReverseDiff.reverse_exec!(tape[$i]::$(typeof(tape[i])))))
-    end
-    push!(body.args, :(return nothing))
-    return :(ReverseDiff.reverse_pass!(tape::$T) = $body)
-end
-
 ###################
 # Pretty Printing #
 ###################

--- a/src/tape.jl
+++ b/src/tape.jl
@@ -77,22 +77,22 @@ end
 # pass compilation #
 ####################
 
-function generate_forward_code(tape::RawTape)
-    expr = Expr(:block)
-    for instruction in tape
-        push!(expr.args, :(ReverseDiff.forward_exec!($instruction)))
+function generate_forward_pass_method{T}(::Type{T}, tape::RawTape)
+    body = Expr(:block)
+    for i in 1:length(tape)
+        push!(body.args, :(ReverseDiff.forward_exec!(tape[$i]::$(typeof(tape[i])))))
     end
-    push!(expr.args, :(return nothing))
-    return expr
+    push!(body.args, :(return nothing))
+    return :(ReverseDiff.forward_pass!(tape::$T) = $body)
 end
 
-function generate_reverse_code(tape::RawTape)
-    expr = Expr(:block)
+function generate_reverse_pass_method{T}(::Type{T}, tape::RawTape)
+    body = Expr(:block)
     for i in length(tape):-1:1
-        push!(expr.args, :(ReverseDiff.reverse_exec!($(tape[i]))))
+        push!(body.args, :(ReverseDiff.reverse_exec!(tape[$i]::$(typeof(tape[i])))))
     end
-    push!(expr.args, :(return nothing))
-    return expr
+    push!(body.args, :(return nothing))
+    return :(ReverseDiff.reverse_pass!(tape::$T) = $body)
 end
 
 ###################

--- a/test/api/HessianTests.jl
+++ b/test/api/HessianTests.jl
@@ -64,13 +64,11 @@ function test_unary_hessian(f, x)
     # with compiled HessianTape
 
     if length(tp.tape) <= 10000 # otherwise compile time can be crazy
-        Hf! = ReverseDiff.compile_hessian(f, seedx)
         ctp = ReverseDiff.compile(tp)
 
-        # circumvent world-age problems (`ctp` and `Hf!` have a future world age)
+        # circumvent world-age problems (`ctp` has a future world age)
         @eval begin
-            test, x = $test, $x
-            ctp, Hf! = $ctp, $Hf!
+            test, x, ctp = $test, $x, $ctp
 
             test_approx(ReverseDiff.hessian!(ctp, x), DiffBase.hessian(test))
 
@@ -78,18 +76,8 @@ function test_unary_hessian(f, x)
             ReverseDiff.hessian!(out, ctp, x)
             test_approx(out, DiffBase.hessian(test))
 
-            out = similar(DiffBase.hessian(test))
-            Hf!(out, x)
-            test_approx(out, DiffBase.hessian(test))
-
             result = DiffBase.HessianResult(x)
             ReverseDiff.hessian!(result, ctp, x)
-            test_approx(DiffBase.value(result), DiffBase.value(test))
-            test_approx(DiffBase.gradient(result), DiffBase.gradient(test))
-            test_approx(DiffBase.hessian(result), DiffBase.hessian(test))
-
-            result = DiffBase.HessianResult(x)
-            Hf!(result, x)
             test_approx(DiffBase.value(result), DiffBase.value(test))
             test_approx(DiffBase.gradient(result), DiffBase.gradient(test))
             test_approx(DiffBase.hessian(result), DiffBase.hessian(test))

--- a/test/api/JacobianTests.jl
+++ b/test/api/JacobianTests.jl
@@ -59,13 +59,12 @@ function test_unary_jacobian(f, x)
     # with compiled JacobianTape
 
     if length(tp.tape) <= COMPILED_TAPE_LIMIT # otherwise compile time can be crazy
-        Jf! = ReverseDiff.compile_jacobian(f, rand(size(x)))
         ctp = ReverseDiff.compile(tp)
 
         # circumvent world-age problems (`ctp` and `Jf!` have a future world age)
         @eval begin
             test_val, test, x = $test_val, $test, $x
-            ctp, Jf! = $ctp, $Jf!
+            ctp = $ctp
 
             test_approx(ReverseDiff.jacobian!(ctp, x), DiffBase.jacobian(test))
 
@@ -73,17 +72,8 @@ function test_unary_jacobian(f, x)
             ReverseDiff.jacobian!(out, ctp, x)
             test_approx(out, DiffBase.jacobian(test))
 
-            out = similar(DiffBase.jacobian(test))
-            Jf!(out, x)
-            test_approx(out, DiffBase.jacobian(test))
-
             result = DiffBase.JacobianResult(test_val, x)
             ReverseDiff.jacobian!(result, ctp, x)
-            test_approx(DiffBase.value(result), DiffBase.value(test))
-            test_approx(DiffBase.jacobian(result), DiffBase.jacobian(test))
-
-            result = DiffBase.JacobianResult(test_val, x)
-            Jf!(result, x)
             test_approx(DiffBase.value(result), DiffBase.value(test))
             test_approx(DiffBase.jacobian(result), DiffBase.jacobian(test))
         end
@@ -156,13 +146,12 @@ function test_unary_jacobian(f!, y, x)
     # with compiled JacobianTape
 
     if length(tp.tape) <= COMPILED_TAPE_LIMIT # otherwise compile time can be crazy
-        Jf! = ReverseDiff.compile_jacobian(f!, y, rand(size(x)))
         ctp = ReverseDiff.compile(tp)
 
         # circumvent world-age problems (`ctp` and `Jf!` have a future world age)
         @eval begin
             test, y, x = $test, $y, $x
-            ctp, Jf! = $ctp, $Jf!
+            ctp = $ctp
 
             out = ReverseDiff.jacobian!(ctp, x)
 
@@ -172,17 +161,8 @@ function test_unary_jacobian(f!, y, x)
             ReverseDiff.jacobian!(out, ctp, x)
             test_approx(out, DiffBase.jacobian(test))
 
-            out = similar(DiffBase.jacobian(test))
-            Jf!(out, x)
-            test_approx(out, DiffBase.jacobian(test))
-
             result = DiffBase.JacobianResult(y, x)
             ReverseDiff.jacobian!(result, ctp, x)
-            test_approx(DiffBase.value(result), DiffBase.value(test))
-            test_approx(DiffBase.jacobian(result), DiffBase.jacobian(test))
-
-            result = DiffBase.JacobianResult(y, x)
-            Jf!(result, x)
             test_approx(DiffBase.value(result), DiffBase.value(test))
             test_approx(DiffBase.jacobian(result), DiffBase.jacobian(test))
         end
@@ -261,14 +241,13 @@ function test_binary_jacobian(f, a, b)
     # with compiled JacobianTape
 
     if length(tp.tape) <= COMPILED_TAPE_LIMIT # otherwise compile time can be crazy
-        Jf! = ReverseDiff.compile_jacobian(f, (rand(size(a)), rand(size(b))))
         ctp = ReverseDiff.compile(tp)
 
         # circumvent world-age problems (`ctp` and `Jf!` have a future world age)
         @eval begin
             test_val, test_a, test_b = $test_val, $test_a, $test_b
             a, b = $a, $b
-            Jf!, ctp = $Jf!, $ctp
+            ctp = $ctp
 
             Ja, Jb = ReverseDiff.jacobian!(ctp, (a, b))
             test_approx(Ja, test_a)
@@ -280,23 +259,9 @@ function test_binary_jacobian(f, a, b)
             test_approx(Ja, test_a)
             test_approx(Jb, test_b)
 
-            Ja = similar(a, length(test_val), length(a))
-            Jb = similar(b, length(test_val), length(b))
-            Jf!((Ja, Jb), (a, b))
-            test_approx(Ja, test_a)
-            test_approx(Jb, test_b)
-
             Ja = DiffBase.JacobianResult(test_val, a)
             Jb = DiffBase.JacobianResult(test_val, b)
             ReverseDiff.jacobian!((Ja, Jb), ctp, (a, b))
-            test_approx(DiffBase.value(Ja), test_val)
-            test_approx(DiffBase.value(Jb), test_val)
-            test_approx(DiffBase.gradient(Ja), test_a)
-            test_approx(DiffBase.gradient(Jb), test_b)
-
-            Ja = DiffBase.JacobianResult(test_val, a)
-            Jb = DiffBase.JacobianResult(test_val, b)
-            Jf!((Ja, Jb), (a, b))
             test_approx(DiffBase.value(Ja), test_val)
             test_approx(DiffBase.value(Jb), test_val)
             test_approx(DiffBase.gradient(Ja), test_a)


### PR DESCRIPTION
This removes `compiled_*(...)` methods in favor of just `compile(*Tape(...))`, and refactors `compile` to separate out the generated code from the tape memory. This enables advanced users to use ReverseDiff in a thread-safe way without generating new functions for each thread.