### PR TITLE
correct the seeding order for seeded_reverse_pass! functions

### DIFF
--- a/src/api/utils.jl
+++ b/src/api/utils.jl
@@ -14,10 +14,10 @@ function seeded_reverse_pass!(result::AbstractArray, output::AbstractArray, inpu
 end
 
 function seeded_reverse_pass!(output::TrackedReal, input::TrackedReal, tape)
-    seed!(output)
+    pull_value!(output)
     unseed!(input)
+    seed!(output)
     reverse_pass!(tape)
-    unseed!(output)
     return deriv(input)
 end
 
@@ -25,8 +25,9 @@ end
 #--------------------------------------------------#
 
 function seeded_reverse_pass!(result, output::TrackedReal, input, tape)
-    seed!(output)
+    pull_value!(output)
     unseed!(input)
+    seed!(output)
     reverse_pass!(tape)
     extract_result!(result, output, input)
     return result
@@ -43,9 +44,10 @@ end
 function seeded_reverse_pass!(result::AbstractArray, output::AbstractArray, input::TrackedArray, tape)
     result_matrix = reshape(result, length(output), length(input))
     input_deriv = deriv(input)
+    pull_value!(output)
     for i in eachindex(output)
-        seed!(output, i)
         unseed!(input)
+        seed!(output, i)
         reverse_pass!(tape)
         for j in eachindex(input)
             result_matrix[i, j] = input_deriv[j]

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -10,7 +10,7 @@ srand(1)
 
 test_println(kind, f, pad = "  ") = println(pad, "testing $(kind): `$(f)`...")
 
-test_approx(A, B) = @test isapprox(A, B, atol = 1e-5)
+@inline test_approx(A, B) = @test isapprox(A, B, atol = 1e-5)
 
 tracked_is(a, b) = value(a) === value(b) && deriv(a) === deriv(b) && tape(a) === tape(b)
 tracked_is(a::AbstractArray, b::AbstractArray) = all(map(tracked_is, a, b))


### PR DESCRIPTION
This fixes #59. Test is added [here](https://github.com/JuliaDiff/DiffBase.jl/pull/3). We'll have to re-run Travis once that's merged and tagged to get representative testing in this PR.

Funnily, enough, this also reveals similar bugs in both ForwardDiff and Calculus - both of them appear to get the wrong answer for the Jacobian of the identity. I've checked locally that this PR enables ReverseDiff to get the correct answer, but once the DiffBase PR is merged, tests will fail here, since ReverseDiff is checking against ForwardDiff, which checks against Calculus.

I'll start working on bug fixes for those packages as well.