### PR TITLE
WIP: replace eval()-ed methods with FunctionWrappers.jl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ notifications:
 script:
  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
  - julia -e 'Pkg.init(); Pkg.add("FunctionWrappers"); Pkg.checkout("FunctionWrappers")'
- - julia -e 'Pkg.clone(pwd()); Pkg.build("ReverseDiff"); Pkg.test("ReverseDiff"; coverage=true)'
+ - julia -e 'Pkg.clone(pwd()); Pkg.build("ReverseDiff"); Pkg.test("ReverseDiff"; coverage=VERSION >= v"0.6-")'
 
 after_success:
   # push coverage results to Coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ notifications:
   email: false
 script:
  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+ - julia -e 'Pkg.init(); Pkg.add("FunctionWrappers"); Pkg.checkout("FunctionWrappers")'
  - julia -e 'Pkg.clone(pwd()); Pkg.build("ReverseDiff"); Pkg.test("ReverseDiff"; coverage=true)'
+
 after_success:
   # push coverage results to Coveralls
   - julia -e 'cd(Pkg.dir("ReverseDiff")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - linux
 julia:
   - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ notifications:
   email: false
 script:
  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
- - julia -e 'Pkg.init(); Pkg.add("FunctionWrappers"); Pkg.checkout("FunctionWrappers")'
  - julia -e 'Pkg.clone(pwd()); Pkg.build("ReverseDiff"); Pkg.test("ReverseDiff"; coverage=VERSION >= v"0.6-")'
 
 after_success:

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.5
 DiffBase 0.0.3 0.3.0
 ForwardDiff 0.3.4 0.5.0
 Compat 0.19.0
+FunctionWrappers

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,4 @@ julia 0.5
 DiffBase 0.0.3 0.3.0
 ForwardDiff 0.3.4 0.5.0
 Compat 0.19.0
-FunctionWrappers
+FunctionWrappers 0.1

--- a/src/ReverseDiff.jl
+++ b/src/ReverseDiff.jl
@@ -3,6 +3,7 @@ __precompile__()
 module ReverseDiff
 
 using Base: RefValue
+using FunctionWrappers: FunctionWrapper
 
 using Compat
 

--- a/src/api/tape.jl
+++ b/src/api/tape.jl
@@ -52,7 +52,7 @@ end
 # CompiledTape #
 ################
 
-immutable CompiledTape{S,T<:AbstractTape} <: AbstractTape
+immutable CompiledTape{T<:AbstractTape} <: AbstractTape
     tape::T
     forward_exec::Vector{FunctionWrapper{Void, Tuple{}}}
     reverse_exec::Vector{FunctionWrapper{Void, Tuple{}}}
@@ -93,23 +93,23 @@ end
 @inline (e::ReverseExecutor)() = reverse_exec!(e.instruction)
 
 """
-    (::Type{CompiledTape{S}}){S,T<:AbstractTape}(t::T)
+    (::Type{CompiledTape}){T<:AbstractTape}(t::T)
 
 Construct a compiled type by wrapping the `forward_exec!` and `reverse_exec!`
 methods on each instruction in the tape.
 """
-function (::Type{CompiledTape{S}}){S,T<:AbstractTape}(t::T)
-    CompiledTape{S,T}(t,
+function (::Type{CompiledTape}){T<:AbstractTape}(t::T)
+    CompiledTape{T}(t,
         [FunctionWrapper{Void, Tuple{}}(ForwardExecutor(instruction)) for instruction in t.tape],
         [FunctionWrapper{Void, Tuple{}}(ReverseExecutor(t.tape[i])) for i in length(t.tape):-1:1]
         )
 end
 
-Base.show{S}(io::IO, t::CompiledTape{S}) = print(io, typeof(t).name, "{$S}($(t.tape.func))")
+Base.show(io::IO, t::CompiledTape) = print(io, typeof(t).name, "($(t.tape.func))")
 
-@compat const CompiledGradient{S,T<:GradientTape} = CompiledTape{S,T}
-@compat const CompiledJacobian{S,T<:JacobianTape} = CompiledTape{S,T}
-@compat const CompiledHessian{S,T<:HessianTape}   = CompiledTape{S,T}
+@compat const CompiledGradient{T<:GradientTape} = CompiledTape{T}
+@compat const CompiledJacobian{T<:JacobianTape} = CompiledTape{T}
+@compat const CompiledHessian{T<:HessianTape}   = CompiledTape{T}
 
 Base.length(ct::CompiledTape) = length(ct.tape)
 
@@ -144,7 +144,7 @@ the tape, the more time compilation may take. Very long tapes (i.e. when `length
 the order of 10000 elements) can take a very long time to compile.
 """
 function compile(t::AbstractTape)
-    ct = CompiledTape{gensym()}(t)
+    ct = CompiledTape(t)
     return ct
 end
 

--- a/src/api/tape.jl
+++ b/src/api/tape.jl
@@ -113,11 +113,6 @@ passed to any API methods that accept `t` (e.g. `gradient!(result, t, input)`).
 In many cases, compiling `t` can significantly speed up execution time. Note that the longer
 the tape, the more time compilation may take. Very long tapes (i.e. when `length(t)` is on
 the order of 10000 elements) can take a very long time to compile.
-
-Note that this function calls `eval` in the `current_module()` to generate functions
-from `t`. Thus, the returned `CompiledTape` will only be useable once the world-age
-counter has caught up with the world-age of the `eval`'d functions (i.e. once the call
-stack has bubbled up to top level).
 """
 function compile(t::AbstractTape)
     ct = CompiledTape{gensym()}(t)

--- a/src/api/tape.jl
+++ b/src/api/tape.jl
@@ -61,7 +61,7 @@ end
 (::Type{CompiledTape{S}}){S,T<:AbstractTape}(t::T) = CompiledTape{S,T}(
     t, 
     [FunctionWrapper{Void, Tuple{}}(() -> forward_exec!(instruction)) for instruction in t.tape],
-    [FunctionWrapper{Void, Tuple{}}(() -> reverse_exec!(instruction)) for instruction in t.tape]
+    [FunctionWrapper{Void, Tuple{}}(() -> reverse_exec!(t.tape[i])) for i in length(t.tape):-1:1]
     )
 
 Base.show{S}(io::IO, t::CompiledTape{S}) = print(io, typeof(t).name, "{$S}($(t.tape.func))")

--- a/src/api/tape.jl
+++ b/src/api/tape.jl
@@ -58,13 +58,13 @@ immutable CompiledTape{S,T<:AbstractTape} <: AbstractTape
     reverse_exec::Vector{FunctionWrapper{Void, Tuple{}}}
 end
 
-struct ForwardExecutor{I <: AbstractInstruction}
+immutable ForwardExecutor{I <: AbstractInstruction}
     instruction::I
 end
 
 @inline (e::ForwardExecutor)() = forward_exec!(e.instruction)
 
-struct ReverseExecutor{I <: AbstractInstruction}
+immutable ReverseExecutor{I <: AbstractInstruction}
     instruction::I
 end
 

--- a/test/api/HessianTests.jl
+++ b/test/api/HessianTests.jl
@@ -66,22 +66,17 @@ function test_unary_hessian(f, x)
     if length(tp.tape) <= 10000 # otherwise compile time can be crazy
         ctp = ReverseDiff.compile(tp)
 
-        # circumvent world-age problems (`ctp` has a future world age)
-        @eval begin
-            test, x, ctp = $test, $x, $ctp
+        test_approx(ReverseDiff.hessian!(ctp, x), DiffBase.hessian(test))
 
-            test_approx(ReverseDiff.hessian!(ctp, x), DiffBase.hessian(test))
+        out = similar(DiffBase.hessian(test))
+        ReverseDiff.hessian!(out, ctp, x)
+        test_approx(out, DiffBase.hessian(test))
 
-            out = similar(DiffBase.hessian(test))
-            ReverseDiff.hessian!(out, ctp, x)
-            test_approx(out, DiffBase.hessian(test))
-
-            result = DiffBase.HessianResult(x)
-            ReverseDiff.hessian!(result, ctp, x)
-            test_approx(DiffBase.value(result), DiffBase.value(test))
-            test_approx(DiffBase.gradient(result), DiffBase.gradient(test))
-            test_approx(DiffBase.hessian(result), DiffBase.hessian(test))
-        end
+        result = DiffBase.HessianResult(x)
+        ReverseDiff.hessian!(result, ctp, x)
+        test_approx(DiffBase.value(result), DiffBase.value(test))
+        test_approx(DiffBase.gradient(result), DiffBase.gradient(test))
+        test_approx(DiffBase.hessian(result), DiffBase.hessian(test))
     end
 end
 


### PR DESCRIPTION
Since this seems like it might not be a terrible idea, I'm opening a PR to figure out whether this is a good change.

As discussed in #70, using `eval()` to generate the forward and reverse pass methods inside `compile()` creates world age issues, which ultimately means that a tape cannot be compiled and used in the same runtime context. This PR fixes that problem by removing the `eval()`ed methods entirely. Instead, to avoid type instability, the compiled tape is augmented with two vectors of concretely typed FunctionWrappers. Each wrapper is built around a functor which, when called, invokes its corresponding instruction's `forward_exec!` or `reverse_exec!` method. 

Performance seems to be ~15% slower on my machine using this branch vs `master` for the rosenbrock example from #70. Hopefully we can improve that...

I've kept the `compile()` method intact for now. `compile()` is *much* faster than before (135ms reduced to ~~8ms~~ 2ms for the rosenbrock example) but it's still not free. 

~~This requires FunctionWrappers master. I've opened an issue there to ask for a new tag: https://github.com/yuyichao/FunctionWrappers.jl/issues/3~~

fixes #70 