### PR TITLE
fix overly-inclusive convert method at supertype boundary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ julia:
   - 0.5
   - 0.6
   - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 notifications:
   email: false
 script:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.5
-DiffBase 0.0.3 0.3.0
+DiffBase 0.0.3 0.4.0
 ForwardDiff 0.3.4 0.5.0
 Compat 0.19.0
 FunctionWrappers 0.1

--- a/src/api/hessians.jl
+++ b/src/api/hessians.jl
@@ -47,7 +47,7 @@ function hessian!(result::DiffResult, f, input::AbstractArray,
     ∇f! = (y, x) -> begin
         gradient_result = DiffResult(zero(eltype(y)), y)
         gradient!(gradient_result, f, x, cfg.gradient_config)
-        DiffBase.value!(result, value(DiffBase.value(gradient_result)))
+        result = DiffBase.value!(result, value(DiffBase.value(gradient_result)))
         return y
     end
     jacobian!(DiffBase.hessian(result), ∇f!,
@@ -92,7 +92,7 @@ end
 function hessian!(result::DiffResult, tape::Union{HessianTape,CompiledHessian}, input::AbstractArray)
     seeded_forward_pass!(tape, input)
     seeded_reverse_pass!(DiffResult(DiffBase.gradient(result), DiffBase.hessian(result)), tape)
-    DiffBase.value!(result, func_hook(tape)(input))
+    result = DiffBase.value!(result, func_hook(tape)(input))
     return result
 end
 

--- a/src/api/utils.jl
+++ b/src/api/utils.jl
@@ -94,7 +94,7 @@ function extract_result!(result::AbstractArray, output::TrackedReal, input::Trac
 end
 
 function extract_result!(result::DiffResult, output::TrackedReal, input::TrackedArray)
-    DiffBase.value!(result, value(output))
+    result = DiffBase.value!(result, value(output))
     copy!(DiffBase.gradient(result), deriv(input))
     return result
 end
@@ -105,7 +105,7 @@ function extract_result!(result::AbstractArray, output::Number)
 end
 
 function extract_result!(result::DiffResult, output::Number)
-    DiffBase.value!(result, output)
+    result = DiffBase.value!(result, output)
     fill_zeros!(DiffBase.gradient(result))
     return result
 end
@@ -118,12 +118,12 @@ function extract_result_value!(result::Tuple, output)
 end
 
 function extract_result_value!(result::DiffResult, output::AbstractArray)
-    DiffBase.value!(value, result, output)
+    result = DiffBase.value!(value, result, output)
     return result
 end
 
 function extract_result_value!(result::DiffResult, output::TrackedArray)
-    DiffBase.value!(result, value(output))
+    result = DiffBase.value!(result, value(output))
     return result
 end
 

--- a/src/tracked.jl
+++ b/src/tracked.jl
@@ -243,6 +243,7 @@ end
     return nothing
 end
 
+Base.convert{T<:TrackedReal}(::Type{Real}, t::T) = t
 Base.convert{R<:Real,T<:TrackedReal}(::Type{R}, t::T) = R(value(t))
 Base.convert{T<:TrackedReal,R<:Real}(::Type{T}, x::R) = TrackedReal{valtype(T),derivtype(T),origintype(T)}(valtype(T)(value(x)))
 


### PR DESCRIPTION
Fixes #82. The former "correct" behavior was actually dependent on a type inference bug, which got fixed in the final Julia v0.6.0 release.

Test added in https://github.com/JuliaDiff/DiffBase.jl/pull/12, so I'm going to wait to merge this until that gets tagged (so I can re-run Travis here with the test).

cc @NHDaly

EDIT: Also made nightly failures allowable, since the plan is to replace this package by the v0.7 release anyway