### PR TITLE
gradients common use case example

### DIFF
--- a/examples/gradient.jl
+++ b/examples/gradient.jl
@@ -56,3 +56,27 @@ gradient(f, inputs, cfg)
 gradient!(results, f, inputs)
 
 gradient(f, inputs)
+
+"""
+    ReverseDiff.makeGradients(f, input :: Vector{<:Real})
+
+Returns `(∇f!, f∇f!, g, yg)`.
+
+`∇f!` takes a value similar to `input`, and returns the gradient at that point.
+This gradient is also written to `g` to allow more efficient use that avoids memory allocation.
+
+`f∇f!` takes a value similar to `input`, and returns both the function value and the gradient at that point.
+This pair (function value, gradient) is also written to `yg` to allow more efficient use that avoids memory allocation.
+
+Note: THIS USE CASE IS NOT THREAD SAFE.
+"""
+makeGradients(f, x0) = begin
+  const f_tape = GradientTape(f, x0)
+  const compiled_f_tape = compile(f_tape)
+  g = similar(x0)
+  yg = DiffBase.GradientResult(g)
+  cfg = GradientConfig(x0)
+  ∇f!(x)  = gradient!(g, compiled_f_tape, x)
+  f∇f!(x) = gradient!(yg, compiled_f_tape, x)
+  return(∇f!, f∇f!, g, yg)
+end

--- a/src/api/gradients.jl
+++ b/src/api/gradients.jl
@@ -80,3 +80,26 @@ function gradient!(result, tape::Union{GradientTape,CompiledGradient}, input)
     seeded_reverse_pass!(result, tape)
     return result
 end
+
+
+"""
+    ReverseDiff.makeGradients(f, input <: Vector{Real})
+
+Returns `(∇f!, f∇f!, g, yg)`.
+
+`∇f!` takes a value similar to `input`, and returns the gradient at that point.
+This gradient is also written to `g` to allow more efficient use that avoids memory allocation.
+
+`f∇f!` takes a value similar to `input`, and returns both the function value and the gradient at that point.
+This pair (function value, gradient) is also written to `yg` to allow more efficient use that avoids memory allocation.
+"""
+makeGradients(f, x0) = begin
+  const f_tape = GradientTape(f, x0)
+  const compiled_f_tape = compile(f_tape)
+  g = similar(x0)
+  yg = DiffBase.GradientResult(g)
+  cfg = GradientConfig(x0)
+  ∇f!(x)  = gradient!(g, compiled_f_tape, x)
+  f∇f!(x) = gradient!(yg, compiled_f_tape, x)
+  return(∇f!, f∇f!, g, yg)
+end

--- a/src/api/gradients.jl
+++ b/src/api/gradients.jl
@@ -83,7 +83,7 @@ end
 
 
 """
-    ReverseDiff.makeGradients(f, input <: Vector{Real})
+    ReverseDiff.makeGradients(f, input :: Vector{<:Real})
 
 Returns `(∇f!, f∇f!, g, yg)`.
 

--- a/src/api/gradients.jl
+++ b/src/api/gradients.jl
@@ -80,26 +80,3 @@ function gradient!(result, tape::Union{GradientTape,CompiledGradient}, input)
     seeded_reverse_pass!(result, tape)
     return result
 end
-
-
-"""
-    ReverseDiff.makeGradients(f, input :: Vector{<:Real})
-
-Returns `(∇f!, f∇f!, g, yg)`.
-
-`∇f!` takes a value similar to `input`, and returns the gradient at that point.
-This gradient is also written to `g` to allow more efficient use that avoids memory allocation.
-
-`f∇f!` takes a value similar to `input`, and returns both the function value and the gradient at that point.
-This pair (function value, gradient) is also written to `yg` to allow more efficient use that avoids memory allocation.
-"""
-makeGradients(f, x0) = begin
-  const f_tape = GradientTape(f, x0)
-  const compiled_f_tape = compile(f_tape)
-  g = similar(x0)
-  yg = DiffBase.GradientResult(g)
-  cfg = GradientConfig(x0)
-  ∇f!(x)  = gradient!(g, compiled_f_tape, x)
-  f∇f!(x) = gradient!(yg, compiled_f_tape, x)
-  return(∇f!, f∇f!, g, yg)
-end


### PR DESCRIPTION
The most common "big win" case for reverse-mode autodiff is for a function from a vector over the reals to the reals. But compared to ForwardDiff.jl, ReverseDiff.jl has some boilerplate and cognitive overhead, because of the need to preallocate the tape.

A simple way around this is to build a wrapper makeGradients like so:
```julia
makeGradients(f, x0) = begin
  const f_tape = GradientTape(f, x0)
  const compiled_f_tape = compile(f_tape)
  g = similar(x0)
  yg = DiffBase.GradientResult(g)
  cfg = GradientConfig(x0)
  ∇f!(x)  = gradient!(g, compiled_f_tape, x)
  f∇f!(x) = gradient!(yg, compiled_f_tape, x)
  return(∇f!, f∇f!, g, yg)
end
```

This seems to me to arrive at the best of both worlds: It's very simple to use, and computation is efficient and requires no allocation. And it returns both the gradient as well as a function that computes the value and gradient together in only one pass. Many algorithms require both of these in order to really be efficient. The wrapper makes building it very simple.

In principle, this could be extended to inputs other than vectors, as well as to computations other than function values and gradients.

As @jrevels pointed out, THE CURRENT IMPLEMENTATION IS NOT THREAD SAFE