### PR TITLE
deprecation fixes for Julia v0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 # Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
-os:
-  - linux
 julia:
-  - 0.6
-  - nightly
+    - 0.7
+    - 1.0
+    - nightly
 matrix:
   allow_failures:
     - julia: nightly
 notifications:
-  email: false
+    email: false
+sudo: false
 script:
- - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
- - julia -e 'Pkg.clone(pwd()); Pkg.build("ReverseDiff"); Pkg.test("ReverseDiff"; coverage=VERSION >= v"0.6-")'
+    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+    - julia -e 'Pkg.clone(pwd()); Pkg.build("ReverseDiff"); Pkg.test("ReverseDiff"; coverage=true)'
 after_success:
-  # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("ReverseDiff")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+    # push coverage results to Coveralls
+    - julia -e 'cd(Pkg.dir("ReverseDiff")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ notifications:
 sudo: false
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'Pkg.clone(pwd()); Pkg.build("ReverseDiff"); Pkg.test("ReverseDiff"; coverage=true)'
+    - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("ReverseDiff"); Pkg.test("ReverseDiff"; coverage=true)'
 after_success:
     # push coverage results to Coveralls
-    - julia -e 'cd(Pkg.dir("ReverseDiff")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+    - julia -e 'using Pkg; cd(Pkg.dir("ReverseDiff")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # ReverseDiff
 
 [![Build Status](https://travis-ci.org/JuliaDiff/ReverseDiff.jl.svg?branch=master)](https://travis-ci.org/JuliaDiff/ReverseDiff.jl)
-[![ReverseDiff](http://pkg.julialang.org/badges/ReverseDiff_0.5.svg)](http://pkg.julialang.org/?pkg=ReverseDiff)
-[![ReverseDiff](http://pkg.julialang.org/badges/ReverseDiff_0.6.svg)](http://pkg.julialang.org/?pkg=ReverseDiff)
 [![Coverage Status](https://coveralls.io/repos/github/JuliaDiff/ReverseDiff.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaDiff/ReverseDiff.jl?branch=master)
 
 [**Go To ReverseDiff's Documentation**](http://www.juliadiff.org/ReverseDiff.jl/)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 
 [**See ReverseDiff Usage Examples**](https://github.com/JuliaDiff/ReverseDiff.jl/tree/master/examples)
 
+**Note: While ReverseDiff technically supports Julia v0.7/v1.0 and is somewhat maintained, it
+is currently not actively developed. Instead, ForwardDiff/ReverseDiff's maintainers are
+focused on the development of a new AD package built on top of [Cassette](https://github.com/jrevels/Cassette.jl).
+In the meantime, it might be worth checking out other reverse-mode AD implementations in Nabla.jl,
+AutoGrad.jl, Flux.jl, or XGrad.jl.**
+
 ReverseDiff implements methods to take **gradients**, **Jacobians**, **Hessians**, and
 higher-order derivatives of native Julia functions (or any callable object, really) using
 **reverse mode automatic differentiation (AD)**.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,9 +1,8 @@
-julia 0.6
+julia 0.7
 DiffResults 0.0.1
-DiffRules 0.0.1
+DiffRules 0.0.4
 NaNMath 0.2.2
 SpecialFunctions 0.1.0
-ForwardDiff 0.6.0
-StaticArrays 0.5.0
-Compat 0.19.0
-FunctionWrappers 0.1
+ForwardDiff 0.8.0
+StaticArrays 0.8.3
+FunctionWrappers 1.0.0

--- a/src/ReverseDiff.jl
+++ b/src/ReverseDiff.jl
@@ -1,11 +1,11 @@
-__precompile__()
-
 module ReverseDiff
 
 using Base: RefValue
-using FunctionWrappers: FunctionWrapper
+using Random
+using LinearAlgebra
+using Statistics
 
-using Compat
+using FunctionWrappers: FunctionWrapper
 
 using DiffResults
 using DiffResults: DiffResult

--- a/src/api/Config.jl
+++ b/src/api/Config.jl
@@ -101,14 +101,14 @@ See `ReverseDiff.jacobian` for a description of acceptable types for `input`.
 """
 function JacobianConfig(output::AbstractArray{D}, input::Tuple, tp::InstructionTape = InstructionTape()) where D
     cfg_input = map(x -> track(similar(x), D, tp), input)
-    cfg_output = track!(similar(output, TrackedReal{D,D,Void}), output, tp)
+    cfg_output = track!(similar(output, TrackedReal{D,D,Nothing}), output, tp)
     return _JacobianConfig(cfg_input, cfg_output, tp)
 end
 
 # we dispatch on V<:Real here because InstructionTape is actually also an AbstractArray
 function JacobianConfig(output::AbstractArray{D}, input::AbstractArray{V}, tp::InstructionTape = InstructionTape()) where {D,V<:Real}
     cfg_input = track(similar(input), D, tp)
-    cfg_output = track!(similar(output, TrackedReal{D,D,Void}), output, tp)
+    cfg_output = track!(similar(output, TrackedReal{D,D,Nothing}), output, tp)
     return _JacobianConfig(cfg_input, cfg_output, tp)
 end
 

--- a/src/api/tape.jl
+++ b/src/api/tape.jl
@@ -54,8 +54,8 @@ end
 
 struct CompiledTape{T<:AbstractTape} <: AbstractTape
     tape::T
-    forward_exec::Vector{FunctionWrapper{Void, Tuple{}}}
-    reverse_exec::Vector{FunctionWrapper{Void, Tuple{}}}
+    forward_exec::Vector{FunctionWrapper{Nothing, Tuple{}}}
+    reverse_exec::Vector{FunctionWrapper{Nothing, Tuple{}}}
 end
 
 """
@@ -100,8 +100,8 @@ methods on each instruction in the tape.
 """
 function CompiledTape(t::T) where T<:AbstractTape
     CompiledTape{T}(t,
-        [FunctionWrapper{Void, Tuple{}}(ForwardExecutor(instruction)) for instruction in t.tape],
-        [FunctionWrapper{Void, Tuple{}}(ReverseExecutor(t.tape[i])) for i in length(t.tape):-1:1]
+        [FunctionWrapper{Nothing, Tuple{}}(ForwardExecutor(instruction)) for instruction in t.tape],
+        [FunctionWrapper{Nothing, Tuple{}}(ReverseExecutor(t.tape[i])) for i in length(t.tape):-1:1]
         )
 end
 

--- a/src/api/utils.jl
+++ b/src/api/utils.jl
@@ -89,13 +89,13 @@ function extract_result!(result::Tuple, output)
 end
 
 function extract_result!(result::AbstractArray, output::TrackedReal, input::TrackedArray)
-    copy!(result, deriv(input))
+    copyto!(result, deriv(input))
     return result
 end
 
 function extract_result!(result::DiffResult, output::TrackedReal, input::TrackedArray)
     result = DiffResults.value!(result, value(output))
-    copy!(DiffResults.gradient(result), deriv(input))
+    copyto!(DiffResults.gradient(result), deriv(input))
     return result
 end
 
@@ -133,7 +133,7 @@ function extract_result_value!(result::AbstractArray, output::AbstractArray)
 end
 
 function extract_result_value!(result::AbstractArray, output::TrackedArray)
-    copy!(result, value(output))
+    copyto!(result, value(output))
     return result
 end
 

--- a/src/derivatives/elementwise.jl
+++ b/src/derivatives/elementwise.jl
@@ -358,11 +358,11 @@ function broadcast_plus(x, y, ::Type{D}) where D
     tp = tape(x, y)
     out = track(value(x) .+ value(y), D, tp)
     cache = (index_bound(x, out), index_bound(y, out))
-    record!(tp, SpecialInstruction, Base.:(.+), (x, y), out, cache)
+    record!(tp, SpecialInstruction, (broadcast, +), (x, y), out, cache)
     return out
 end
 
-@noinline function special_forward_exec!(instruction::SpecialInstruction{typeof(.+)})
+@noinline function special_forward_exec!(instruction::SpecialInstruction{Tuple{typeof(broadcast),typeof(+)}})
     a, b = instruction.input
     output = instruction.output
     pull_value!(a)
@@ -371,7 +371,7 @@ end
     return nothing
 end
 
-@noinline function special_reverse_exec!(instruction::SpecialInstruction{typeof(.+)})
+@noinline function special_reverse_exec!(instruction::SpecialInstruction{Tuple{typeof(broadcast),typeof(+)}})
     a, b = instruction.input
     output = instruction.output
     output_deriv = deriv(output)
@@ -389,11 +389,11 @@ function broadcast_minus(x, y, ::Type{D}) where D
     tp = tape(x, y)
     out = track(value(x) .- value(y), D, tp)
     cache = (index_bound(x, out), index_bound(y, out))
-    record!(tp, SpecialInstruction, Base.:(.-), (x, y), out, cache)
+    record!(tp, SpecialInstruction, (broadcast, -), (x, y), out, cache)
     return out
 end
 
-@noinline function special_forward_exec!(instruction::SpecialInstruction{typeof(.-)})
+@noinline function special_forward_exec!(instruction::SpecialInstruction{Tuple{typeof(broadcast),typeof(-)}})
     a, b = instruction.input
     output = instruction.output
     pull_value!(a)
@@ -402,7 +402,7 @@ end
     return nothing
 end
 
-@noinline function special_reverse_exec!(instruction::SpecialInstruction{typeof(.-)})
+@noinline function special_reverse_exec!(instruction::SpecialInstruction{Tuple{typeof(broadcast),typeof(-)}})
     a, b = instruction.input
     output = instruction.output
     output_deriv = deriv(output)
@@ -420,11 +420,11 @@ function broadcast_mul(x, y, ::Type{D}) where D
     tp = tape(x, y)
     out = track(value(x) .* value(y), D, tp)
     cache = (index_bound(x, out), index_bound(y, out))
-    record!(tp, SpecialInstruction, Base.:(.*), (x, y), out, cache)
+    record!(tp, SpecialInstruction, (broadcast, *), (x, y), out, cache)
     return out
 end
 
-@noinline function special_forward_exec!(instruction::SpecialInstruction{typeof(.*)})
+@noinline function special_forward_exec!(instruction::SpecialInstruction{Tuple{typeof(broadcast),typeof(*)}})
     a, b = instruction.input
     output = instruction.output
     pull_value!(a)
@@ -433,7 +433,7 @@ end
     return nothing
 end
 
-@noinline function special_reverse_exec!(instruction::SpecialInstruction{typeof(.*)})
+@noinline function special_reverse_exec!(instruction::SpecialInstruction{Tuple{typeof(broadcast),typeof(*)}})
     a, b = instruction.input
     output = instruction.output
     output_deriv = deriv(output)
@@ -467,11 +467,11 @@ function broadcast_rdiv(x, y, ::Type{D}) where D
     cache = (n_partials, d_partials,
              index_bound(x, out), index_bound(y, out),
              index_bound(n_partials, out), index_bound(d_partials, out))
-    record!(tp, SpecialInstruction, Base.:(./), (x, y), out, cache)
+    record!(tp, SpecialInstruction, (broadcast, /), (x, y), out, cache)
     return out
 end
 
-@noinline function special_forward_exec!(instruction::SpecialInstruction{typeof(./)})
+@noinline function special_forward_exec!(instruction::SpecialInstruction{Tuple{typeof(broadcast),typeof(/)}})
     a, b = instruction.input
     a_value, b_value = value(a), value(b)
     n_partials, d_partials = instruction.cache
@@ -484,7 +484,7 @@ end
     return nothing
 end
 
-@noinline function special_reverse_exec!(instruction::SpecialInstruction{typeof(./)})
+@noinline function special_reverse_exec!(instruction::SpecialInstruction{Tuple{typeof(broadcast),typeof(/)}})
     a, b = instruction.input
     output = instruction.output
     output_deriv = deriv(output)
@@ -506,11 +506,11 @@ function broadcast_ldiv(x, y, ::Type{D}) where D
     cache = (n_partials, d_partials,
              index_bound(x, out), index_bound(y, out),
              index_bound(n_partials, out), index_bound(d_partials, out))
-    record!(tp, SpecialInstruction, Base.:(.\), (x, y), out, cache)
+    record!(tp, SpecialInstruction, (broadcast, \), (x, y), out, cache)
     return out
 end
 
-@noinline function special_forward_exec!(instruction::SpecialInstruction{typeof(.\)})
+@noinline function special_forward_exec!(instruction::SpecialInstruction{Tuple{typeof(broadcast),typeof(\)}})
     a, b = instruction.input
     a_value, b_value = value(a), value(b)
     n_partials, d_partials = instruction.cache
@@ -523,7 +523,7 @@ end
     return nothing
 end
 
-@noinline function special_reverse_exec!(instruction::SpecialInstruction{typeof(.\)})
+@noinline function special_reverse_exec!(instruction::SpecialInstruction{Tuple{typeof(broadcast),typeof(\)}})
     a, b = instruction.input
     output = instruction.output
     output_deriv = deriv(output)
@@ -563,11 +563,11 @@ function broadcast_pow(x, y, ::Type{D}) where D
     cache = (bs_partials, ex_partials,
              index_bound(x, out), index_bound(y, out),
              index_bound(bs_partials, out), index_bound(ex_partials, out))
-    record!(tp, SpecialInstruction, Base.:(.^), (x, y), out, cache)
+    record!(tp, SpecialInstruction, (broadcast, ^), (x, y), out, cache)
     return out
 end
 
-@noinline function special_forward_exec!(instruction::SpecialInstruction{typeof(.^)})
+@noinline function special_forward_exec!(instruction::SpecialInstruction{Tuple{typeof(broadcast),typeof(^)}})
     a, b = instruction.input
     a_value, b_value = value(a), value(b)
     bs_partials, ex_partials = instruction.cache
@@ -580,7 +580,7 @@ end
     return nothing
 end
 
-@noinline function special_reverse_exec!(instruction::SpecialInstruction{typeof(.^)})
+@noinline function special_reverse_exec!(instruction::SpecialInstruction{Tuple{typeof(broadcast),typeof(^)}})
     a, b = instruction.input
     output = instruction.output
     output_deriv = deriv(output)

--- a/src/derivatives/linalg/special.jl
+++ b/src/derivatives/linalg/special.jl
@@ -2,7 +2,7 @@
 # det #
 #######
 
-function Base.det(x::TrackedArray{V,D}) where {V,D}
+function LinearAlgebra.det(x::TrackedArray{V,D}) where {V,D}
     tp = tape(x)
     x_value = value(x)
     det_x_value = det(x_value)
@@ -36,7 +36,7 @@ end
 # inv #
 #######
 
-function Base.inv(x::TrackedArray{V,D}) where {V,D}
+function LinearAlgebra.inv(x::TrackedArray{V,D}) where {V,D}
     tp = tape(x)
     out_value = inv(value(x))
     out = track(out_value, D, tp)
@@ -49,8 +49,8 @@ end
     output = instruction.output
     output_value, output_deriv = value(output), deriv(output)
     output_tmp1, output_tmp2 = instruction.cache
-    A_mul_Bc!(output_tmp1, output_deriv, output_value)
-    Ac_mul_B!(output_tmp2, output_value, output_tmp1)
+    mul!(output_tmp1, output_deriv, adjoint(output_value))
+    mul!(output_tmp2, adjoint(output_value), output_tmp1)
     decrement_deriv!(instruction.input, output_tmp2)
     unseed!(output)
     return nothing

--- a/src/derivatives/propagation.jl
+++ b/src/derivatives/propagation.jl
@@ -24,7 +24,7 @@ efficiency.
 
 index_bound(x::Any, ::AbstractArray{T,N}) where {T,N} = nothing
 
-index_bound(x::AbstractArray, ::AbstractArray{T,N}) where {T,N} = CartesianIndex{N}(ntuple(i -> size(x, i), Val{N}))
+index_bound(x::AbstractArray, ::AbstractArray{T,N}) where {T,N} = CartesianIndex{N}(ntuple(i -> size(x, i), Val(N)))
 
 ###################
 # increment_deriv #
@@ -89,14 +89,14 @@ end
 
 function diffresult_increment_deriv!(input::AbstractArray, x::AbstractArray,
                                      results, p::Int, bound::CartesianIndex)
-    for i in CartesianRange(size(x))
+    for i in CartesianIndices(size(x))
         increment_deriv!(input, x[i] * getpartial(results[i], p), min(bound, i))
     end
     return nothing
 end
 
 function diffresult_increment_deriv!(input::TrackedReal, x::AbstractArray,
-                                     results, p::Int, ::Void)
+                                     results, p::Int, ::Nothing)
     pull_deriv!(input)
     input_deriv = input.deriv
     for i in eachindex(results)
@@ -116,13 +116,13 @@ end
 
 function broadcast_increment_deriv!(input::AbstractArray, x::AbstractArray,
                                     bound::CartesianIndex)
-    for i in CartesianRange(size(x))
+    for i in CartesianIndices(size(x))
         increment_deriv!(input, x[i], min(bound, i))
     end
     return nothing
 end
 
-function broadcast_increment_deriv!(input::TrackedReal, x::AbstractArray, ::Void)
+function broadcast_increment_deriv!(input::TrackedReal, x::AbstractArray, ::Nothing)
     pull_deriv!(input)
     input_deriv = input.deriv
     for i in x
@@ -140,7 +140,7 @@ function broadcast_increment_deriv!(input::AbstractArray, x::AbstractArray,
                                     partials::AbstractArray,
                                     input_bound::CartesianIndex,
                                     partials_bound::CartesianIndex)
-    for i in CartesianRange(size(x))
+    for i in CartesianIndices(size(x))
         current_deriv = x[i] * partials[min(partials_bound, i)]
         increment_deriv!(input, current_deriv, min(input_bound, i))
     end
@@ -148,7 +148,7 @@ function broadcast_increment_deriv!(input::AbstractArray, x::AbstractArray,
 end
 
 function broadcast_increment_deriv!(input::TrackedReal, x::AbstractArray,
-                                    partials::AbstractArray, ::Void, ::CartesianIndex)
+                                    partials::AbstractArray, ::Nothing, ::CartesianIndex)
     pull_deriv!(input)
     input_deriv = input.deriv
     for i in eachindex(x)
@@ -168,15 +168,15 @@ end
 
 function broadcast_increment_deriv!(input::AbstractArray, x::AbstractArray,
                                     partial::Real, input_bound::CartesianIndex,
-                                    ::Void)
-    for i in CartesianRange(size(x))
+                                    ::Nothing)
+    for i in CartesianIndices(size(x))
         increment_deriv!(input, x[i] * partial, min(input_bound, i))
     end
     return nothing
 end
 
 function broadcast_increment_deriv!(input::TrackedReal, x::AbstractArray,
-                                    partial::Real, ::Void, ::Void)
+                                    partial::Real, ::Nothing, ::Nothing)
     pull_deriv!(input)
     input_deriv = input.deriv
     for i in eachindex(x)
@@ -193,13 +193,13 @@ end
 
 function broadcast_decrement_deriv!(input::AbstractArray, x::AbstractArray,
                                     bound::CartesianIndex)
-    for i in CartesianRange(size(x))
+    for i in CartesianIndices(size(x))
         decrement_deriv!(input, x[i], min(bound, i))
     end
     return nothing
 end
 
-function broadcast_decrement_deriv!(input::TrackedReal, x::AbstractArray, ::Void)
+function broadcast_decrement_deriv!(input::TrackedReal, x::AbstractArray, ::Nothing)
     pull_deriv!(input)
     input_deriv = input.deriv
     for i in x
@@ -216,7 +216,7 @@ end
 
 function reduction_increment_deriv!(input::AbstractArray, x::AbstractArray,
                                     bound::CartesianIndex)
-    for i in CartesianRange(size(input))
+    for i in CartesianIndices(size(input))
         increment_deriv!(input, x[min(bound, i)], i)
     end
     return nothing

--- a/src/derivatives/scalars.jl
+++ b/src/derivatives/scalars.jl
@@ -4,13 +4,13 @@
 
 for (M, f, arity) in DiffRules.diffrules()
     if arity == 1
-        @eval @inline $M.$(f)(t::TrackedReal) = ForwardOptimize($f)(t)
+        @eval @inline $M.$(f)(t::TrackedReal) = ForwardOptimize($M.$(f))(t)
     elseif arity == 2
-        @eval @inline $M.$(f)(a::TrackedReal, b::TrackedReal) = ForwardOptimize($f)(a, b)
+        @eval @inline $M.$(f)(a::TrackedReal, b::TrackedReal) = ForwardOptimize($M.$(f))(a, b)
         for R in REAL_TYPES
             @eval begin
-                @inline $M.$(f)(a::TrackedReal, b::$R) = ForwardOptimize($f)(a, b)
-                @inline $M.$(f)(a::$R, b::TrackedReal) = ForwardOptimize($f)(a, b)
+                @inline $M.$(f)(a::TrackedReal, b::$R) = ForwardOptimize($M.$(f))(a, b)
+                @inline $M.$(f)(a::$R, b::TrackedReal) = ForwardOptimize($M.$(f))(a, b)
             end
         end
     end

--- a/src/tracked.jl
+++ b/src/tracked.jl
@@ -33,11 +33,11 @@ missing-ness of the origin, and it's worth explaining why we don't take these ap
 
 The first alternative is to encode the lack of an origin as a parameter in the
 `TrackedReal` type. Indeed, this is exactly what we do if the origin of a `TrackedReal` is a
-constructor like `zero`, setting `O` to `Void`. However, this strategy is not a viable
+constructor like `zero`, setting `O` to `Nothing`. However, this strategy is not a viable
 solution for origin-less `TrackedReal`s that result from conversions. For example, take the
 expression `y = convert(::Type{T<:TrackedReal}, x::Real)`. `y` will not have an origin, but
 `isa(y, T)` MUST hold true regardless. This could break in a world where `T` forcibly
-specifies an origin of type `O != Void`.
+specifies an origin of type `O != Nothing`.
 
 The second alternative is to use `Nullable` + `isnull`. This solution would work, but it
 overcomplicates the API and would incur unneccesary pointer loads during re-validation,
@@ -58,7 +58,7 @@ end
 
 TrackedReal(v::V, a::D, tp::InstructionTape, i::Int, o::O) where {V,D,O} = TrackedReal{V,D,O}(v, a, tp, i, o)
 
-TrackedReal(v::V, a::D, tp::InstructionTape = NULL_TAPE) where {V,D} = TrackedReal{V,D,Void}(v, a, tp)
+TrackedReal(v::V, a::D, tp::InstructionTape = NULL_TAPE) where {V,D} = TrackedReal{V,D,Nothing}(v, a, tp)
 
 # TrackedArray #
 #--------------#
@@ -89,7 +89,7 @@ end
 istracked(x) = false
 istracked(::TrackedReal) = true
 istracked(::TrackedArray) = true
-istracked(::AbstractArray{T}) where {T} = T <: TrackedReal || !(isleaftype(T))
+istracked(::AbstractArray{T}) where {T} = T <: TrackedReal || !(isconcretetype(T))
 
 @inline value(x) = x
 @inline value(x::AbstractArray) = istracked(x) ? map(value, x) : x
@@ -145,7 +145,7 @@ end
 ###########
 
 @inline value!(t::TrackedReal, v::Real) = (t.value = v; nothing)
-@inline value!(t::TrackedArray, v::AbstractArray) = (copy!(value(t), v); nothing)
+@inline value!(t::TrackedArray, v::AbstractArray) = (copyto!(value(t), v); nothing)
 
 function value!(t::NTuple{N,Any}, v::NTuple{N,Any}) where N
     for i in eachindex(t)
@@ -155,7 +155,7 @@ function value!(t::NTuple{N,Any}, v::NTuple{N,Any}) where N
 end
 
 @inline deriv!(t::TrackedReal, v::Real) = (t.deriv = v; nothing)
-@inline deriv!(t::TrackedArray, v::AbstractArray) = (copy!(deriv(t), v); nothing)
+@inline deriv!(t::TrackedArray, v::AbstractArray) = (copyto!(deriv(t), v); nothing)
 
 function deriv!(t::NTuple{N,Any}, v::NTuple{N,Any}) where N
     for i in eachindex(t)
@@ -255,15 +255,7 @@ for R in REAL_TYPES
 end
 
 Base.promote_rule(::Type{R}, ::Type{TrackedReal{V,D,O}}) where {R<:Real,V,D,O} = TrackedReal{promote_type(R,V),D,O}
-Base.promote_rule(::Type{TrackedReal{V1,D1,O1}}, ::Type{TrackedReal{V2,D2,O2}}) where {V1,V2,D1,D2,O1,O2} = TrackedReal{promote_type(V1,V2),promote_type(D1,D2),Void}
-
-Base.promote_array_type(_, ::Type{T}, ::Type{F}) where {T<:TrackedReal, F<:AbstractFloat} = promote_type(T, F)
-Base.promote_array_type(_, ::Type{T}, ::Type{F}, ::Type{S}) where {T<:TrackedReal, F<:AbstractFloat, S} = S
-Base.promote_array_type(_, ::Type{F}, ::Type{T}) where {F<:AbstractFloat, T<:TrackedReal} = promote_type(T, F)
-Base.promote_array_type(_, ::Type{F}, ::Type{T}, ::Type{S}) where {F<:AbstractFloat, T<:TrackedReal, S} = S
-
-Base.r_promote(::typeof(+), t::T) where {T<:TrackedReal} = t
-Base.r_promote(::typeof(*), t::T) where {T<:TrackedReal} = t
+Base.promote_rule(::Type{TrackedReal{V1,D1,O1}}, ::Type{TrackedReal{V2,D2,O2}}) where {V1,V2,D1,D2,O1,O2} = TrackedReal{promote_type(V1,V2),promote_type(D1,D2),Nothing}
 
 ###########################
 # AbstractArray Interface #
@@ -276,19 +268,19 @@ colon2range(s, ::Colon) = s
 
 function index_iterable(shape::NTuple{N,Any}, i::NTuple{M,Any}) where {N,M}
     if N < M
-        return index_iterable(shape, ntuple(n -> i[n], Val{N}))
+        return index_iterable(shape, ntuple(n -> i[n], Val(N)))
     elseif M < N && isa(last(i), Colon)
-        return index_iterable(shape, ntuple(n -> (n > M ? Colon() : i[n]), Val{N}))
+        return index_iterable(shape, ntuple(n -> (n > M ? Colon() : i[n]), Val(N)))
     else
         return Base.Iterators.product(map(colon2range, shape[1:M], i)...)
     end
 end
 
-for T in (:Range, :Colon, :(Union{Colon,Range}))
+for T in (:AbstractRange, :Colon, :(Union{Colon,AbstractRange}))
     @eval function Base.getindex(t::TrackedArray, i::$(T)...)
         tp = tape(t)
         out = TrackedArray(value(t)[i...], deriv(t)[i...], tp)
-        idx = index_iterable(indices(t), i)
+        idx = index_iterable(axes(t), i)
         record!(tp, SpecialInstruction, getindex, (t, idx), out)
         return out
     end
@@ -324,14 +316,14 @@ Base.IndexStyle(::TrackedArray) = IndexLinear()
 
 Base.size(t::TrackedArray) = size(value(t))
 
-Base.copy(t::T) where {T<:TrackedArray} = t
+Base.copy(t::TrackedArray) = t
 
-Base.ones(t::TrackedArray{V,D}) where {V,D} = ones(TrackedReal{V,D,Void}, size(t))
+Base.similar(t::TrackedArray, args::Union{Integer, AbstractUnitRange}...) = similar(value(t), eltype(t), args...)
 
-Base.zeros(t::TrackedArray{V,D}) where {V,D} = zeros(TrackedReal{V,D,Void}, size(t))
+Base.similar(t::TrackedArray, T::Type, args::Union{Integer, AbstractUnitRange}...) = similar(value(t), T, args...)
 
 reshape_body = :(TrackedArray(reshape(value(t), dims), reshape(deriv(t), dims), tape(t)))
-@eval Base.reshape(t::TrackedArray, dims::Type{Val{N}}) where {N} = $reshape_body
+@eval Base.reshape(t::TrackedArray, dims::Val{N}) where {N} = $reshape_body
 @eval Base.reshape(t::TrackedArray, dims::Tuple{Vararg{Int,N}}) where {N} = $reshape_body
 @eval Base.reshape(t::TrackedArray, dims::Int64...) = $reshape_body
 @eval Base.reshape(t::TrackedArray, dims::AbstractUnitRange...) = $reshape_body
@@ -358,7 +350,7 @@ Base.one(::Type{TrackedReal{V,D,O}}) where {V,D,O} = TrackedReal{V,D,O}(one(V))
 Base.zero(::Type{TrackedReal{V,D,O}}) where {V,D,O} = TrackedReal{V,D,O}(zero(V))
 
 Base.rand(::Type{TrackedReal{V,D,O}}) where {V,D,O} = TrackedReal{V,D,O}(rand(V))
-Base.rand(rng::AbstractRNG, ::Type{TrackedReal{V,D,O}}) where {V,D,O} = TrackedReal{V,D,O}(rand(rng, V))
+Base.rand(rng::Random.AbstractRNG, ::Type{TrackedReal{V,D,O}}) where {V,D,O} = TrackedReal{V,D,O}(rand(rng, V))
 
 Base.eps(t::TrackedReal) = eps(value(t))
 Base.eps(::Type{T}) where {T<:TrackedReal} = eps(valtype(T))
@@ -374,6 +366,9 @@ Base.trunc(::Type{R}, t::TrackedReal) where {R<:Real} = trunc(R, value(t))
 
 Base.round(t::TrackedReal) = round(value(t))
 Base.round(::Type{R}, t::TrackedReal) where {R<:Real} = round(R, value(t))
+
+Base.oneunit(t::TrackedReal) = one(t)
+Base.oneunit(::Type{T}) where {T<:TrackedReal} = one(T)
 
 ################
 # track/track! #
@@ -391,7 +386,7 @@ track!(t::TrackedArray, x::AbstractArray) = (value!(t, x); unseed!(t); t)
 
 track!(t::TrackedReal, x::Real) = (value!(t, x); unseed!(t); t)
 
-function track!(t::AbstractArray{TrackedReal{D,D,Void}}, x::AbstractArray, tp::InstructionTape) where D
+function track!(t::AbstractArray{TrackedReal{D,D,Nothing}}, x::AbstractArray, tp::InstructionTape) where D
     for i in eachindex(t)
         t[i] = track(x[i], D, tp)
     end
@@ -402,7 +397,7 @@ end
 # Pretty Printing #
 ###################
 
-idstr(x) = string(base(62, object_id(x)))[1:3]
+idstr(x) = string(objectid(x), base=62)[1:3]
 
 function Base.show(io::IO, t::TrackedReal)
     tape_id = hastape(t) ? idstr(t.tape) : "---"

--- a/test/MacrosTests.jl
+++ b/test/MacrosTests.jl
@@ -1,14 +1,9 @@
 module MacrosTests
 
-using ReverseDiff, ForwardDiff, Base.Test, StaticArrays
+using ReverseDiff, ForwardDiff, Test, StaticArrays
 using ForwardDiff: Dual, Partials, partials
 
 include(joinpath(dirname(@__FILE__), "utils.jl"))
-
-println("testing macros (@forward, @skip, etc.)...")
-tic()
-
-############################################################################################
 
 tp = InstructionTape()
 x, a, b = rand(3)
@@ -185,9 +180,5 @@ test_skip(g5, x, tp)
 ReverseDiff.@skip g6 = (a, b) -> sqrt(a^2 + b^2)
 test_println("@skip anonymous functions", g6)
 test_skip(g6, a, b, tp)
-
-############################################################################################
-
-println("done (took $(toq()) seconds)")
 
 end # module

--- a/test/TapeTests.jl
+++ b/test/TapeTests.jl
@@ -1,14 +1,9 @@
 module TapeTests
 
-using ReverseDiff, Base.Test
+using ReverseDiff, Test
 using ReverseDiff: SpecialInstruction, ScalarInstruction, NULL_TAPE
 
 include(joinpath(dirname(@__FILE__), "utils.jl"))
-
-println("testing InstructionTape/AbstractInstructions...")
-tic()
-
-############################################################################################
 
 for Instr in (SpecialInstruction, ScalarInstruction)
     x, y, k = rand(3), rand(2, 1), rand()
@@ -40,9 +35,5 @@ for Instr in (SpecialInstruction, ScalarInstruction)
     ReverseDiff.record!(NULL_TAPE, Instr, +, (x, y, k), z, c)
     @test isempty(NULL_TAPE)
 end
-
-############################################################################################
-
-println("done (took $(toq()) seconds)")
 
 end # module

--- a/test/api/ConfigTests.jl
+++ b/test/api/ConfigTests.jl
@@ -1,13 +1,10 @@
 module ConfigTests
 
-using ReverseDiff, Base.Test
+using ReverseDiff, Test
 
 include(joinpath(dirname(@__FILE__), "../utils.jl"))
 
-println("testing Config...")
-tic()
-
-issimilar(x::Void, y::Void) = true
+issimilar(x::Nothing, y::Nothing) = true
 issimilar(x::AbstractArray, y::AbstractArray) = typeof(x) === typeof(y) && size(x) === size(y)
 issimilar(x::GradientConfig, y::GradientConfig) = issimilar(x.input, y.input) && x.tape === y.tape
 issimilar(x::JacobianConfig, y::JacobianConfig) = issimilar(x.output, y.output) && issimilar(x.input, y.input) && x.tape === y.tape
@@ -42,19 +39,19 @@ for Config in (GradientConfig, JacobianConfig)
 end
 
 cfg = JacobianConfig(z, x, tp)
-zt = similar(z, ReverseDiff.TrackedReal{eltype(z),eltype(z),Void})
+zt = similar(z, ReverseDiff.TrackedReal{eltype(z),eltype(z),Nothing})
 @test issimilar(cfg.input, track(x, eltype(z), tp))
 @test issimilar(cfg.output, track!(zt, z, tp))
 @test cfg.tape === tp
 
 cfg = JacobianConfig(z, (x, y), tp)
-zt = similar(z, ReverseDiff.TrackedReal{eltype(z),eltype(z),Void})
+zt = similar(z, ReverseDiff.TrackedReal{eltype(z),eltype(z),Nothing})
 @test issimilar(cfg.output, track!(zt, z, tp))
 @test issimilar(cfg.input, (track(x, eltype(z), tp), track(y, eltype(z), tp)))
 @test cfg.tape === tp
 
 cfg1 = JacobianConfig(z, (x, y), tp)
-zt = similar(z, ReverseDiff.TrackedReal{eltype(z),eltype(z),Void})
+zt = similar(z, ReverseDiff.TrackedReal{eltype(z),eltype(z),Nothing})
 cfg2 = JacobianConfig(DiffResults.JacobianResult(z), (x, y), tp)
 @test issimilar(cfg1, cfg2)
 
@@ -76,9 +73,5 @@ cfg = HessianConfig(x, Int, gtp, jtp)
 cfg = HessianConfig(DiffResults.HessianResult(y), x, gtp, jtp)
 @test issimilar(cfg.gradient_config, GradientConfig(track(x, Int), gtp))
 @test issimilar(cfg.jacobian_config, JacobianConfig(y, x, jtp))
-
-############################################################################################
-
-println("done (took $(toq()) seconds)")
 
 end # module

--- a/test/api/GradientTests.jl
+++ b/test/api/GradientTests.jl
@@ -1,13 +1,8 @@
 module GradientTests
 
-using DiffTests, ForwardDiff, ReverseDiff, Base.Test
+using DiffTests, ForwardDiff, ReverseDiff, Test
 
 include(joinpath(dirname(@__FILE__), "../utils.jl"))
-
-println("testing gradient/gradient!...")
-tic()
-
-############################################################################################
 
 function test_unary_gradient(f, x)
     test = ForwardDiff.gradient!(DiffResults.GradientResult(x), f, x)
@@ -42,7 +37,7 @@ function test_unary_gradient(f, x)
 
     # with GradientTape
 
-    seedx = rand(size(x))
+    seedx = rand(eltype(x), size(x))
     tp = ReverseDiff.GradientTape(f, seedx)
 
     test_approx(ReverseDiff.gradient!(tp, x), DiffResults.gradient(test))
@@ -128,7 +123,7 @@ function test_ternary_gradient(f, a, b, c)
 
     # with GradientTape
 
-    tp = ReverseDiff.GradientTape(f, (rand(size(a)), rand(size(b)), rand(size(c))))
+    tp = ReverseDiff.GradientTape(f, (rand(eltype(a), size(a)), rand(eltype(b), size(b)), rand(eltype(c), size(c))))
 
     ∇a, ∇b, ∇c = ReverseDiff.gradient!(tp, (a, b, c))
     test_approx(∇a, test_a)
@@ -191,9 +186,5 @@ for f in DiffTests.TERNARY_MATRIX_TO_NUMBER_FUNCS
     test_println("TERNARY_MATRIX_TO_NUMBER_FUNCS", f)
     test_ternary_gradient(f, rand(5, 5), rand(5, 5), rand(5, 5))
 end
-
-############################################################################################
-
-println("done (took $(toq()) seconds)")
 
 end # module

--- a/test/api/HessianTests.jl
+++ b/test/api/HessianTests.jl
@@ -1,18 +1,15 @@
 module HessianTests
 
-using DiffTests, ForwardDiff, ReverseDiff, Base.Test
+using DiffTests, ForwardDiff, ReverseDiff, Test
 
 include(joinpath(dirname(@__FILE__), "../utils.jl"))
-
-println("testing hessian/hessian!...")
-tic()
 
 # Circumvent type inference bug where an erroneous `Any` eltype derails the computation
 # during tests, but not outside of the tests. This is really hacky, but I couldn't figure
 # out enough of an MRE for the bug to report it...
 ReverseDiff.hessian(DiffTests.mat2num_1, rand(3, 3))
 
-############################################################################################
+hess_test_approx(a, b) = test_approx(a, b, 1e-4)
 
 function test_unary_hessian(f, x)
     test = DiffResults.HessianResult(x)
@@ -20,68 +17,68 @@ function test_unary_hessian(f, x)
 
     # without HessianConfig
 
-    test_approx(ReverseDiff.hessian(f, x), DiffResults.hessian(test))
+    hess_test_approx(ReverseDiff.hessian(f, x), DiffResults.hessian(test))
 
     out = similar(DiffResults.hessian(test))
     ReverseDiff.hessian!(out, f, x)
-    test_approx(out, DiffResults.hessian(test))
+    hess_test_approx(out, DiffResults.hessian(test))
 
     result = DiffResults.HessianResult(x)
     ReverseDiff.hessian!(result, f, x)
-    test_approx(DiffResults.value(result), DiffResults.value(test))
-    test_approx(DiffResults.gradient(result), DiffResults.gradient(test))
-    test_approx(DiffResults.hessian(result), DiffResults.hessian(test))
+    hess_test_approx(DiffResults.value(result), DiffResults.value(test))
+    hess_test_approx(DiffResults.gradient(result), DiffResults.gradient(test))
+    hess_test_approx(DiffResults.hessian(result), DiffResults.hessian(test))
 
     # with HessianConfig
 
     cfg = ReverseDiff.HessianConfig(x)
 
-    test_approx(ReverseDiff.hessian(f, x, cfg), DiffResults.hessian(test))
+    hess_test_approx(ReverseDiff.hessian(f, x, cfg), DiffResults.hessian(test))
 
     out = similar(DiffResults.hessian(test))
     ReverseDiff.hessian!(out, f, x, cfg)
-    test_approx(out, DiffResults.hessian(test))
+    hess_test_approx(out, DiffResults.hessian(test))
 
     result = DiffResults.HessianResult(x)
     cfg = ReverseDiff.HessianConfig(result, x)
     ReverseDiff.hessian!(result, f, x, cfg)
-    test_approx(DiffResults.value(result), DiffResults.value(test))
-    test_approx(DiffResults.gradient(result), DiffResults.gradient(test))
-    test_approx(DiffResults.hessian(result), DiffResults.hessian(test))
+    hess_test_approx(DiffResults.value(result), DiffResults.value(test))
+    hess_test_approx(DiffResults.gradient(result), DiffResults.gradient(test))
+    hess_test_approx(DiffResults.hessian(result), DiffResults.hessian(test))
 
     # with HessianTape
 
-    seedx = rand(size(x))
+    seedx = rand(eltype(x), size(x))
     tp = ReverseDiff.HessianTape(f, seedx)
 
-    test_approx(ReverseDiff.hessian!(tp, x), DiffResults.hessian(test))
+    hess_test_approx(ReverseDiff.hessian!(tp, x), DiffResults.hessian(test))
 
     out = similar(DiffResults.hessian(test))
     ReverseDiff.hessian!(out, tp, x)
-    test_approx(out, DiffResults.hessian(test))
+    hess_test_approx(out, DiffResults.hessian(test))
 
     result = DiffResults.HessianResult(x)
     ReverseDiff.hessian!(result, tp, x)
-    test_approx(DiffResults.value(result), DiffResults.value(test))
-    test_approx(DiffResults.gradient(result), DiffResults.gradient(test))
-    test_approx(DiffResults.hessian(result), DiffResults.hessian(test))
+    hess_test_approx(DiffResults.value(result), DiffResults.value(test))
+    hess_test_approx(DiffResults.gradient(result), DiffResults.gradient(test))
+    hess_test_approx(DiffResults.hessian(result), DiffResults.hessian(test))
 
     # with compiled HessianTape
 
     if length(tp.tape) <= 10000 # otherwise compile time can be crazy
         ctp = ReverseDiff.compile(tp)
 
-        test_approx(ReverseDiff.hessian!(ctp, x), DiffResults.hessian(test))
+        hess_test_approx(ReverseDiff.hessian!(ctp, x), DiffResults.hessian(test))
 
         out = similar(DiffResults.hessian(test))
         ReverseDiff.hessian!(out, ctp, x)
-        test_approx(out, DiffResults.hessian(test))
+        hess_test_approx(out, DiffResults.hessian(test))
 
         result = DiffResults.HessianResult(x)
         ReverseDiff.hessian!(result, ctp, x)
-        test_approx(DiffResults.value(result), DiffResults.value(test))
-        test_approx(DiffResults.gradient(result), DiffResults.gradient(test))
-        test_approx(DiffResults.hessian(result), DiffResults.hessian(test))
+        hess_test_approx(DiffResults.value(result), DiffResults.value(test))
+        hess_test_approx(DiffResults.gradient(result), DiffResults.gradient(test))
+        hess_test_approx(DiffResults.hessian(result), DiffResults.hessian(test))
     end
 end
 
@@ -94,9 +91,5 @@ for f in DiffTests.VECTOR_TO_NUMBER_FUNCS
     test_println("VECTOR_TO_NUMBER_FUNCS", f)
     test_unary_hessian(f, rand(5))
 end
-
-############################################################################################
-
-println("done (took $(toq()) seconds)")
 
 end # module

--- a/test/api/JacobianTests.jl
+++ b/test/api/JacobianTests.jl
@@ -1,13 +1,8 @@
 module JacobianTests
 
-using DiffTests, ForwardDiff, ReverseDiff, Base.Test
+using DiffTests, ForwardDiff, ReverseDiff, Test
 
 include(joinpath(dirname(@__FILE__), "../utils.jl"))
-
-println("testing jacobian/jacobian!...")
-tic()
-
-############################################################################################
 
 function test_unary_jacobian(f, x)
     test_val = f(x)
@@ -43,7 +38,7 @@ function test_unary_jacobian(f, x)
 
     # with JacobianTape
 
-    tp = ReverseDiff.JacobianTape(f, rand(size(x)))
+    tp = ReverseDiff.JacobianTape(f, rand(eltype(x), size(x)))
 
     test_approx(ReverseDiff.jacobian!(tp, x), DiffResults.jacobian(test))
 
@@ -84,20 +79,20 @@ function test_unary_jacobian(f!, y, x)
     out = ReverseDiff.jacobian(f!, y, x)
     test_approx(y, DiffResults.value(test))
     test_approx(out, DiffResults.jacobian(test))
-    copy!(y, y_original)
+    copyto!(y, y_original)
 
     out = similar(DiffResults.jacobian(test))
     ReverseDiff.jacobian!(out, f!, y, x)
     test_approx(y,   DiffResults.value(test))
     test_approx(out, DiffResults.jacobian(test))
-    copy!(y, y_original)
+    copyto!(y, y_original)
 
     result = DiffResults.JacobianResult(y, x)
     ReverseDiff.jacobian!(result, f!, y, x)
     @test DiffResults.value(result) == y
     test_approx(y, DiffResults.value(test))
     test_approx(DiffResults.jacobian(result), DiffResults.jacobian(test))
-    copy!(y, y_original)
+    copyto!(y, y_original)
 
     # with JacobianConfig
 
@@ -106,24 +101,24 @@ function test_unary_jacobian(f!, y, x)
     out = ReverseDiff.jacobian(f!, y, x, cfg)
     test_approx(y,   DiffResults.value(test))
     test_approx(out, DiffResults.jacobian(test))
-    copy!(y, y_original)
+    copyto!(y, y_original)
 
     out = similar(DiffResults.jacobian(test))
     ReverseDiff.jacobian!(out, f!, y, x, cfg)
     test_approx(y,   DiffResults.value(test))
     test_approx(out, DiffResults.jacobian(test))
-    copy!(y, y_original)
+    copyto!(y, y_original)
 
     result = DiffResults.JacobianResult(y, x)
     ReverseDiff.jacobian!(result, f!, y, x, cfg)
     @test DiffResults.value(result) == y
     test_approx(y, DiffResults.value(test))
     test_approx(DiffResults.jacobian(result), DiffResults.jacobian(test))
-    copy!(y, y_original)
+    copyto!(y, y_original)
 
     # with JacobianTape
 
-    tp = ReverseDiff.JacobianTape(f!, y, rand(size(x)))
+    tp = ReverseDiff.JacobianTape(f!, y, rand(eltype(x), size(x)))
 
     out = ReverseDiff.jacobian!(tp, x)
     test_approx(out, DiffResults.jacobian(test))
@@ -206,7 +201,7 @@ function test_binary_jacobian(f, a, b)
 
     # with JacobianTape
 
-    tp = ReverseDiff.JacobianTape(f, (rand(size(a)), rand(size(b))))
+    tp = ReverseDiff.JacobianTape(f, (rand(eltype(a), size(a)), rand(eltype(b), size(b))))
 
     Ja, Jb = ReverseDiff.jacobian!(tp, (a, b))
     test_approx(Ja, test_a)
@@ -266,16 +261,6 @@ for f in DiffTests.BINARY_MATRIX_TO_MATRIX_FUNCS
     test_binary_jacobian(f, rand(5, 5), rand(5, 5))
 end
 
-
-############################################################################################
-
-println("done (took $(toq()) seconds)")
-
-println("testing nested jacobians...")
-tic()
-
-############################################################################################
-
 for f in (DiffTests.ARRAY_TO_ARRAY_FUNCS..., DiffTests.MATRIX_TO_MATRIX_FUNCS...)
     test_println("ARRAY_TO_ARRAY_FUNCS + MATRIX_TO_MATRIX_FUNCS", f)
 
@@ -289,7 +274,7 @@ for f in (DiffTests.ARRAY_TO_ARRAY_FUNCS..., DiffTests.MATRIX_TO_MATRIX_FUNCS...
 
     # with JacobianTape
 
-    tp = ReverseDiff.JacobianTape(y -> ReverseDiff.jacobian(f, y), rand(size(x)))
+    tp = ReverseDiff.JacobianTape(y -> ReverseDiff.jacobian(f, y), rand(eltype(x), size(x)))
     J = ReverseDiff.jacobian!(tp, x)
     test_approx(J, test)
 end
@@ -312,8 +297,8 @@ for f in DiffTests.BINARY_MATRIX_TO_MATRIX_FUNCS
 
     # with JacobianTape
 
-    ra = ReverseDiff.JacobianTape(y -> ReverseDiff.jacobian(x -> f(x, b), y), rand(size(a)))
-    rb = ReverseDiff.JacobianTape(y -> ReverseDiff.jacobian(x -> f(a, x), y), rand(size(b)))
+    ra = ReverseDiff.JacobianTape(y -> ReverseDiff.jacobian(x -> f(x, b), y), rand(eltype(a), size(a)))
+    rb = ReverseDiff.JacobianTape(y -> ReverseDiff.jacobian(x -> f(a, x), y), rand(eltype(b), size(b)))
     Ja = ReverseDiff.jacobian!(ra, a)
     Jb = ReverseDiff.jacobian!(rb, b)
     test_approx(Ja, test_a)
@@ -326,10 +311,5 @@ for f in DiffTests.BINARY_MATRIX_TO_MATRIX_FUNCS
     # test_approx(Ja test_a)
     # test_approx(Jb test_b)
 end
-
-############################################################################################
-
-println("done (took $(toq()) seconds)")
-
 
 end # module

--- a/test/derivatives/ElementwiseTests.jl
+++ b/test/derivatives/ElementwiseTests.jl
@@ -1,13 +1,9 @@
 module ElementwiseTests
 
-using ReverseDiff, ForwardDiff, Base.Test, DiffRules, SpecialFunctions, NaNMath, DiffTests
+using ReverseDiff, ForwardDiff, Test, DiffRules, SpecialFunctions, NaNMath, DiffTests
 
 include(joinpath(dirname(@__FILE__), "../utils.jl"))
 
-println("testing elementwise derivatives (both forward and reverse passes)")
-tic()
-
-############################################################################################
 x, y = rand(3, 3), rand(3, 3)
 a, b = rand(3), rand(3)
 n = rand()
@@ -386,6 +382,7 @@ end
 DOMAIN_ERR_FUNCS = (:asec, :acsc, :asecd, :acscd, :acoth, :acosh)
 
 for (M, fsym, arity) in DiffRules.diffrules()
+    fsym === :rem2pi && continue
     if arity == 1
         f = eval(:($M.$fsym))
         is_domain_err_func = in(fsym, DOMAIN_ERR_FUNCS)
@@ -420,9 +417,5 @@ for f in DiffTests.BINARY_BROADCAST_OPS
     test_broadcast(f, f, n, a, tp, true)
     test_broadcast(f, f, a, n, tp, true)
 end
-
-############################################################################################
-
-println("done (took $(toq()) seconds)")
 
 end # module

--- a/test/derivatives/ScalarTests.jl
+++ b/test/derivatives/ScalarTests.jl
@@ -1,13 +1,9 @@
 module ScalarTests
 
-using ReverseDiff, ForwardDiff, Base.Test, DiffRules, SpecialFunctions, NaNMath
+using ReverseDiff, ForwardDiff, Test, DiffRules, SpecialFunctions, NaNMath
 
 include(joinpath(dirname(@__FILE__), "../utils.jl"))
 
-println("testing scalar derivatives (both forward and reverse passes)")
-tic()
-
-############################################################################################
 x, a, b = rand(3)
 tp = InstructionTape()
 int_range = 1:10
@@ -140,8 +136,9 @@ end
 DOMAIN_ERR_FUNCS = (:asec, :acsc, :asecd, :acscd, :acoth, :acosh)
 
 for (M, f, arity) in DiffRules.diffrules()
+    f === :rem2pi && continue
     if arity == 1
-        test_println("forward-mode unary scalar functions", f)
+        test_println("forward-mode unary scalar functions", string(M, ".", f))
         is_domain_err_func = in(f, DOMAIN_ERR_FUNCS)
         n = is_domain_err_func ? x + 1 : x
         test_forward(eval(:($M.$f)), n, tp, is_domain_err_func)
@@ -165,9 +162,5 @@ for f in ReverseDiff.SKIPPED_BINARY_SCALAR_FUNCS
     test_println("SKIPPED_BINARY_SCALAR_FUNCS", f)
     test_skip(eval(f), a, b, tp)
 end
-
-############################################################################################
-
-println("done (took $(toq()) seconds)")
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,13 +2,42 @@ const TESTDIR = dirname(@__FILE__)
 
 test_println(kind, f, pad = "  ") = println(pad, "testing $(kind): `$(f)`...")
 
-include(joinpath(TESTDIR, "TapeTests.jl"))
-include(joinpath(TESTDIR, "TrackedTests.jl"))
-include(joinpath(TESTDIR, "MacrosTests.jl"))
-include(joinpath(TESTDIR, "derivatives/ScalarTests.jl"))
-include(joinpath(TESTDIR, "derivatives/LinAlgTests.jl"))
-include(joinpath(TESTDIR, "derivatives/ElementwiseTests.jl"))
-include(joinpath(TESTDIR, "api/ConfigTests.jl"))
-include(joinpath(TESTDIR, "api/GradientTests.jl"))
-include(joinpath(TESTDIR, "api/JacobianTests.jl"))
-include(joinpath(TESTDIR, "api/HessianTests.jl"))
+println("running TapeTests...")
+t = @elapsed include(joinpath(TESTDIR, "TapeTests.jl"))
+println("done (took $t seconds).")
+
+println("running TrackedTests...")
+t = @elapsed include(joinpath(TESTDIR, "TrackedTests.jl"))
+println("done (took $t seconds).")
+
+println("running MacrosTests...")
+t = @elapsed include(joinpath(TESTDIR, "MacrosTests.jl"))
+println("done (took $t seconds).")
+
+println("running ScalarTests...")
+t = @elapsed include(joinpath(TESTDIR, "derivatives/ScalarTests.jl"))
+println("done (took $t seconds).")
+
+println("running LinAlgTests...")
+t = @elapsed include(joinpath(TESTDIR, "derivatives/LinAlgTests.jl"))
+println("done (took $t seconds).")
+
+println("running ElementwiseTests...")
+t = @elapsed include(joinpath(TESTDIR, "derivatives/ElementwiseTests.jl"))
+println("done (took $t seconds).")
+
+println("running ConfigTests...")
+t = @elapsed include(joinpath(TESTDIR, "api/ConfigTests.jl"))
+println("done (took $t seconds).")
+
+println("running GradientTests...")
+t = @elapsed include(joinpath(TESTDIR, "api/GradientTests.jl"))
+println("done (took $t seconds).")
+
+println("running JacobianTests...")
+t = @elapsed include(joinpath(TESTDIR, "api/JacobianTests.jl"))
+println("done (took $t seconds).")
+
+println("running HessianTests...")
+t = @elapsed include(joinpath(TESTDIR, "api/HessianTests.jl"))
+println("done (took $t seconds).")

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -2,6 +2,8 @@ using ReverseDiff: InstructionTape, GradientConfig, JacobianConfig, HessianConfi
                    value, deriv, tape, valtype,
                    derivtype, track, track!
 
+using Random
+
 const COMPILED_TAPE_LIMIT = 5000
 
 # These functions correctly emit NaNs for certain arguments, but ReverseDiff's test
@@ -12,11 +14,11 @@ const SKIPPED_BINARY_SCALAR_TESTS = Symbol[:hankelh1, :hankelh1x, :hankelh2, :ha
 
 # make RNG deterministic, and thus make result inaccuracies
 # deterministic so we don't have to retune EPS for arbitrary inputs
-srand(1)
+Random.seed!(1)
 
 test_println(kind, f, pad = "  ") = println(pad, "testing $(kind): `$(f)`...")
 
-@inline test_approx(A, B) = @test isapprox(A, B, atol = 1e-5)
+@inline test_approx(A, B, _atol = 1e-5) = @test isapprox(A, B, atol = _atol)
 
 tracked_is(a, b) = value(a) === value(b) && deriv(a) === deriv(b) && tape(a) === tape(b)
 tracked_is(a::AbstractArray, b::AbstractArray) = all(map(tracked_is, a, b))


### PR DESCRIPTION
Let's see what CI thinks of this. Tests pass locally with no depwarns AFAICT.

The hardest part was updating the `A_mul_B`-style functions to the equivalents using `Adjoint` and `Transpose`; I kinda followed the quickest path to getting things working and the result is pretty messy. The painful number of method overloads there makes me really happy that Cassette exists now and that future AD implementations won't need to struggle through this... 😛 

I didn't end up actually updating to the new broadcast machinery. Doing so would be the Right Thing To Do™️, but tests seem to pass without it. We can put in the work to update to the new broadcast machinery later if the current set of (previously kosher, now hacky) broadcast overloads ends up causing any practical issues.

Assuming CI passes, this closes #109.

