### PR TITLE
Add constructor <--> convert pun for TrackedReal

### DIFF
--- a/src/tracked.jl
+++ b/src/tracked.jl
@@ -60,6 +60,10 @@ TrackedReal(v::V, a::D, tp::InstructionTape, i::Int, o::O) where {V,D,O} = Track
 
 TrackedReal(v::V, a::D, tp::InstructionTape = NULL_TAPE) where {V,D} = TrackedReal{V,D,Nothing}(v, a, tp)
 
+# we define these special cases so that the "constructor <--> convert" pun holds for `TrackedReal`
+# this is Jarett's favorite piece of code. A true work of art.
+@inline TrackedReal{V,D,O}(x::TrackedReal) where {V,D,O} = convert(TrackedReal{V,D,O}, x)
+
 # TrackedArray #
 #--------------#
 


### PR DESCRIPTION
Fixes generic codes like

```julia
using OrdinaryDiffEq, ForwardDiff, ReverseDiff, ParameterizedFunctions

df = @ode_def begin
  dx = a*x - b*x*y
  dy = -c*y + x*y
end a b c

u0 = [1.,1.]; tspan = (0., 10.); p = [1.5,1.0,3.0];

function auto_sen_l2(f, init, tspan, p, t, alg=Vern6(); diffalg=ForwardDiff.gradient)
    test_f(p) = begin
        prob = ODEProblem(f,eltype(p).(init),eltype(p).(tspan),p)
        sol = solve(prob,alg,abstol=1e-5,reltol=1e-7,saveat=t)
        sum(sol.u) do x
            sum(z->(1-z)^2/2, x)
        end
    end
    diffalg(test_f, p)
end

t = 0:0.5:10
auto_sen_l2(df, u0, tspan, p, t; diffalg=ReverseDiff.gradient)
```

which rely on `T(x) == convert(T,x)` for `Number` types.