### PR TITLE
fill, vcat, hcat, cat, reshape, any, and all custom adjoints

### DIFF
--- a/src/ReverseDiff.jl
+++ b/src/ReverseDiff.jl
@@ -28,6 +28,7 @@ const SKIPPED_BINARY_SCALAR_FUNCS = Symbol[:isequal, :isless, :<, :>, :(==), :(!
 include("tape.jl")
 include("tracked.jl")
 include("macros.jl")
+include("derivatives/arrays.jl")
 include("derivatives/propagation.jl")
 include("derivatives/scalars.jl")
 include("derivatives/elementwise.jl")

--- a/src/derivatives/arrays.jl
+++ b/src/derivatives/arrays.jl
@@ -37,12 +37,15 @@ for f in [:hcat, :vcat]
         cnames = map(_ -> gensym(), c)
         @eval Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::Union{TrackedArray,TrackedReal}, xs::Union{AbstractArray,Number}...) = track($f, $(cnames...), x, xs...)
     end
+    for i = 0:2, c = combinations([:AbstractVecOrMat, :TrackedVecOrMat], i)
+        cnames = map(_ -> gensym(), c)
+        @eval Base.$f($([:($x::$c{T}) for (x, c) in zip(cnames, c)]...), x::TrackedVecOrMat{T}, xs::AbstractVecOrMat{T}...) where T = track($f, $(cnames...), x, xs...)
+    end
+    for i = 0:2, c = combinations([:AbstractVector, :TrackedVector], i)
+        cnames = map(_ -> gensym(), c)
+        @eval Base.$f($([:($x::$c{T}) for (x, c) in zip(cnames, c)]...), x::TrackedVector{T}, xs::AbstractVector{T}...) where T = track($f, $(cnames...), x, xs...)
+    end
     @eval begin
-        Base.$f(x::TrackedVecOrMat{T}, xs::AbstractVecOrMat{T}...) where T = track($f, x, xs...)
-        Base.$f(x1::TrackedVecOrMat{T}, x2::TrackedVecOrMat{T}, xs::AbstractVecOrMat{T}...) where T = track($f, x1, x2, xs...)
-        Base.$f(x::TrackedVector{T}, xs::AbstractVector{T}...) where T = track($f, x, xs...)
-        Base.$f(x1::TrackedVector{T}, x2::TrackedVector{T}, xs::AbstractVector{T}...) where T = track($f, x1, x2, xs...)
-
         @grad function $f(x::Real)
             $f(value(x)), (Δ) -> (Δ[1],)
         end
@@ -93,7 +96,7 @@ end
 end
 
 Base.cat(Xs::TrackedArray...; dims) = track(cat, Xs...; dims = dims)
-@grad function cat(Xs::TrackedArray{<:Any, D}...; dims) where {D}
+@grad function cat(Xs::RTA{<:Any, D}...; dims) where {D}
     Xs_value = value.(Xs)
     return cat(Xs_value...; dims = dims), Δ -> begin
         start = ntuple(i -> 0, Val(ndims(Δ)))
@@ -108,3 +111,12 @@ Base.cat(Xs::TrackedArray...; dims) = track(cat, Xs...; dims = dims)
         return (Δs...,)
     end
 end
+
+#############
+## reshape ##
+#############
+
+Base.reshape(xs::TrackedArray, dims::Union{Colon,Int}...) = reshape(xs, dims)
+Base.reshape(xs::TrackedArray, dims::Tuple{Vararg{Union{Int,Colon}}}) = reshape(xs, Base._reshape_uncolon(xs, dims))
+Base.reshape(xs::TrackedArray, dims::Tuple{Vararg{Int}}) = track(reshape, xs, dims)
+@grad reshape(xs, dims) = reshape(value(xs), dims), Δ -> (reshape(Δ, size(xs)),nothing)

--- a/src/derivatives/arrays.jl
+++ b/src/derivatives/arrays.jl
@@ -57,7 +57,7 @@ end
 
 @grad function vcat(xs::Union{TrackedVector, TrackedMatrix}...)
     xs_value = value.(xs)
-    out_value = vcat(xs_value...)
+    out_value = reduce(vcat,xs_value)
     function back(Δ)
         start = 0
         Δs = map(xs) do xsi

--- a/src/derivatives/arrays.jl
+++ b/src/derivatives/arrays.jl
@@ -37,6 +37,7 @@ for f in [:hcat, :vcat]
         cnames = map(_ -> gensym(), c)
         @eval Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::Union{TrackedArray,TrackedReal}, xs::Union{AbstractArray,Number}...) = track($f, $(cnames...), x, xs...)
     end
+    #=
     for i = 0:2, c = combinations([:AbstractVecOrMat, :TrackedVecOrMat], i)
         cnames = map(_ -> gensym(), c)
         @eval Base.$f($([:($x::$c{T}) for (x, c) in zip(cnames, c)]...), x::TrackedVecOrMat{T}, xs::AbstractVecOrMat{T}...) where T = track($f, $(cnames...), x, xs...)
@@ -45,6 +46,7 @@ for f in [:hcat, :vcat]
         cnames = map(_ -> gensym(), c)
         @eval Base.$f($([:($x::$c{T}) for (x, c) in zip(cnames, c)]...), x::TrackedVector{T}, xs::AbstractVector{T}...) where T = track($f, $(cnames...), x, xs...)
     end
+    =#
     @eval begin
         @grad function $f(x::Real)
             $f(value(x)), (Δ) -> (Δ[1],)
@@ -96,7 +98,7 @@ end
 end
 
 Base.cat(Xs::TrackedArray...; dims) = track(cat, Xs...; dims = dims)
-@grad function cat(Xs::RTA{<:Any, D}...; dims) where {D}
+@grad function cat(Xs::TrackedArray{<:Any, D}...; dims) where {D}
     Xs_value = value.(Xs)
     return cat(Xs_value...; dims = dims), Δ -> begin
         start = ntuple(i -> 0, Val(ndims(Δ)))
@@ -111,12 +113,3 @@ Base.cat(Xs::TrackedArray...; dims) = track(cat, Xs...; dims = dims)
         return (Δs...,)
     end
 end
-
-#############
-## reshape ##
-#############
-
-Base.reshape(xs::TrackedArray, dims::Union{Colon,Int}...) = reshape(xs, dims)
-Base.reshape(xs::TrackedArray, dims::Tuple{Vararg{Union{Int,Colon}}}) = reshape(xs, Base._reshape_uncolon(xs, dims))
-Base.reshape(xs::TrackedArray, dims::Tuple{Vararg{Int}}) = track(reshape, xs, dims)
-@grad reshape(xs, dims) = reshape(value(xs), dims), Δ -> (reshape(Δ, size(xs)),nothing)

--- a/src/derivatives/arrays.jl
+++ b/src/derivatives/arrays.jl
@@ -37,17 +37,12 @@ for f in [:hcat, :vcat]
         cnames = map(_ -> gensym(), c)
         @eval Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::Union{TrackedArray,TrackedReal}, xs::Union{AbstractArray,Number}...) = track($f, $(cnames...), x, xs...)
     end
-    #=
-    for i = 0:2, c = combinations([:AbstractVecOrMat, :TrackedVecOrMat], i)
-        cnames = map(_ -> gensym(), c)
-        @eval Base.$f($([:($x::$c{T}) for (x, c) in zip(cnames, c)]...), x::TrackedVecOrMat{T}, xs::AbstractVecOrMat{T}...) where T = track($f, $(cnames...), x, xs...)
-    end
-    for i = 0:2, c = combinations([:AbstractVector, :TrackedVector], i)
-        cnames = map(_ -> gensym(), c)
-        @eval Base.$f($([:($x::$c{T}) for (x, c) in zip(cnames, c)]...), x::TrackedVector{T}, xs::AbstractVector{T}...) where T = track($f, $(cnames...), x, xs...)
-    end
-    =#
     @eval begin
+        Base.$f(x::TrackedVecOrMat{T}, xs::AbstractVecOrMat{T}...) where T = track($f, x, xs...)
+        Base.$f(x1::TrackedVecOrMat{T}, x2::TrackedVecOrMat{T}, xs::AbstractVecOrMat{T}...) where T = track($f, x1, x2, xs...)
+        Base.$f(x::TrackedVector{T}, xs::AbstractVector{T}...) where T = track($f, x, xs...)
+        Base.$f(x1::TrackedVector{T}, x2::TrackedVector{T}, xs::AbstractVector{T}...) where T = track($f, x1, x2, xs...)
+
         @grad function $f(x::Real)
             $f(value(x)), (Δ) -> (Δ[1],)
         end

--- a/src/derivatives/arrays.jl
+++ b/src/derivatives/arrays.jl
@@ -1,0 +1,122 @@
+##########
+## fill ##
+##########
+
+function Base.fill(
+    value::TrackedReal,
+    dims::Vararg{Union{Integer, AbstractUnitRange}},
+)
+    return track(fill, value, dims...)
+end
+@grad function fill(v::Real, dims...)
+    return fill(value(v), dims...), function(Δ)
+        size(Δ) ≢  dims && error("Dimension mismatch")
+        return (sum(Δ), map(_->nothing, dims)...)
+    end
+end
+
+###############
+## any & all ##
+###############
+
+Base.any(f::Function, x::TrackedArray; dims=:) = any(f, value(x), dims = dims)
+Base.all(f::Function, x::TrackedArray; dims=:) = all(f, value(x), dims = dims)
+
+#########
+## cat ##
+#########
+
+function combinations(xs, n)
+    n < 1 && return [[]]
+    cs = combinations(xs, n-1)
+    [[x, c...] for x in xs, c in cs]
+end
+
+for f in [:hcat, :vcat]
+    for i = 0:2, c = combinations([:AbstractArray, :TrackedArray, :Number, :TrackedReal], i)
+        cnames = map(_ -> gensym(), c)
+        @eval Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::Union{TrackedArray,TrackedReal}, xs::Union{AbstractArray,Number}...) = track($f, $(cnames...), x, xs...)
+    end
+    for i = 0:2, c = combinations([:AbstractVecOrMat, :TrackedVecOrMat], i)
+        cnames = map(_ -> gensym(), c)
+        @eval Base.$f($([:($x::$c{T}) for (x, c) in zip(cnames, c)]...), x::TrackedVecOrMat{T}, xs::AbstractVecOrMat{T}...) where T = track($f, $(cnames...), x, xs...)
+    end
+    for i = 0:2, c = combinations([:AbstractVector, :TrackedVector], i)
+        cnames = map(_ -> gensym(), c)
+        @eval Base.$f($([:($x::$c{T}) for (x, c) in zip(cnames, c)]...), x::TrackedVector{T}, xs::AbstractVector{T}...) where T = track($f, $(cnames...), x, xs...)
+    end
+    @eval begin
+        @grad function $f(x::Real)
+            $f(value(x)), (Δ) -> (Δ[1],)
+        end
+        @grad function $f(x1::Real, x2::Real)
+            $f(value(x1), value(x2)), (Δ) -> (Δ[1], Δ[2])
+        end
+        @grad function $f(x1::AbstractVector, x2::Real)
+            $f(value(x1), value(x2)), (Δ) -> (Δ[1:length(x1)], Δ[length(x1)+1])
+        end
+    end
+end
+
+@grad function vcat(xs::Union{TrackedVector, TrackedMatrix}...)
+    xs_value = value.(xs)
+    out_value = vcat(xs_value...)
+    function back(Δ)
+        start = 0
+        Δs = map(xs) do xsi
+          x = map(_ -> :, size(xsi))
+          i = isempty(x) ? x : Base.tail(x)
+          d = Δ[start+1:start+size(xsi,1), i...]
+          start += size(xsi, 1)
+          d
+        end
+        return (Δs...,)
+    end
+    return out_value, back
+end
+
+@grad function hcat(xs::Union{TrackedVector, TrackedMatrix}...)
+    xs_value = value.(xs)
+    out_value = hcat(xs_value...)
+    function back(Δ)
+        start = 0
+        Δs = map(xs) do xsi
+          d = if ndims(xsi) == 1
+            Δ[:, start+1]
+          else
+            i = map(_ -> :, size(xsi)) |> Base.tail |> Base.tail
+            Δ[:, start+1:start+size(xsi,2), i...]
+          end
+          start += size(xsi, 2)
+          d
+        end
+        return (Δs...,)
+    end        
+    return out_value, back
+end
+
+Base.cat(Xs::TrackedArray...; dims) = track(cat, Xs...; dims = dims)
+@grad function cat(Xs::RTA{<:Any, D}...; dims) where {D}
+    Xs_value = value.(Xs)
+    return cat(Xs_value...; dims = dims), Δ -> begin
+        start = ntuple(i -> 0, Val(ndims(Δ)))
+        Δs = map(Xs) do xs
+          dim_xs = 1:ndims(xs)
+          till_xs = ntuple((i -> i in dims ? (i in dim_xs ? size(xs,i) : 1) : 0), Val(ndims(Δ)))
+          xs_in_Δ = ntuple(i -> till_xs[i] > 0 ? (start[i]+1:start[i]+till_xs[i]) : Colon(), Val(ndims(Δ)))
+          d = reshape(Δ[xs_in_Δ...],size(xs))
+          start = start .+ till_xs
+          d
+        end
+        return (Δs...,)
+    end
+end
+
+#############
+## reshape ##
+#############
+
+Base.reshape(xs::TrackedArray, dims::Union{Colon,Int}...) = reshape(xs, dims)
+Base.reshape(xs::TrackedArray, dims::Tuple{Vararg{Union{Int,Colon}}}) = reshape(xs, Base._reshape_uncolon(xs, dims))
+Base.reshape(xs::TrackedArray, dims::Tuple{Vararg{Int}}) = track(reshape, xs, dims)
+@grad reshape(xs, dims) = reshape(value(xs), dims), Δ -> (reshape(Δ, size(xs)),nothing)

--- a/src/derivatives/arrays.jl
+++ b/src/derivatives/arrays.jl
@@ -36,7 +36,8 @@ for f in [:hcat, :vcat]
     for i = 0:2, c = combinations([:AbstractVector, :TrackedVector, :AbstractMatrix, :TrackedMatrix, :Number, :TrackedReal], i)
         cnames = map(_ -> gensym(), c)
         @eval begin
-            Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::TrackedArray) = track($f, $(cnames...), x)
+            Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::TrackedVector) = track($f, $(cnames...), x)
+            Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::TrackedMatrix) = track($f, $(cnames...), x)
             Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::TrackedReal) = track($f, $(cnames...), x)
         end
         for T in [
@@ -47,7 +48,8 @@ for f in [:hcat, :vcat]
             :(Union{AbstractVector, Number}),
         ]
             @eval begin
-                Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::TrackedArray, xs::$T...) = track($f, $(cnames...), x, xs...)
+                Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::TrackedVector, xs::$T...) = track($f, $(cnames...), x, xs...)
+                Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::TrackedMatrix, xs::$T...) = track($f, $(cnames...), x, xs...)
                 Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::TrackedReal, xs::$T...) = track($f, $(cnames...), x, xs...)
             end
         end

--- a/src/derivatives/arrays.jl
+++ b/src/derivatives/arrays.jl
@@ -38,6 +38,8 @@ for f in [:hcat, :vcat]
         @eval Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::Union{TrackedArray,TrackedReal}, xs::Union{AbstractArray,Number}...) = track($f, $(cnames...), x, xs...)
     end
     @eval begin
+        Base.$f(xs::TrackedVector{T}...) where T = track($f, xs...)
+        Base.$f(xs::TrackedMatrix{T}...) where T = track($f, xs...)
         Base.$f(x::TrackedVecOrMat{T}, xs::AbstractVecOrMat{T}...) where T = track($f, x, xs...)
         Base.$f(x1::TrackedVecOrMat{T}, x2::TrackedVecOrMat{T}, xs::AbstractVecOrMat{T}...) where T = track($f, x1, x2, xs...)
         Base.$f(x::TrackedVector{T}, xs::AbstractVector{T}...) where T = track($f, x, xs...)

--- a/src/derivatives/arrays.jl
+++ b/src/derivatives/arrays.jl
@@ -57,7 +57,7 @@ for f in [:hcat, :vcat]
     end
 end
 
-@grad function vcat(xs::Union{TrackedVector, TrackedMatrix}...)
+@grad function vcat(xs::AbstractVecOrMat...)
     xs_value = value.(xs)
     out_value = reduce(vcat,xs_value)
     function back(Δ)
@@ -74,7 +74,7 @@ end
     return out_value, back
 end
 
-@grad function hcat(xs::Union{TrackedVector, TrackedMatrix}...)
+@grad function hcat(xs::AbstractVecOrMat...)
     xs_value = value.(xs)
     out_value = reduce(hcat,xs_value)
     function back(Δ)
@@ -95,7 +95,7 @@ end
 end
 
 Base.cat(Xs::TrackedArray...; dims) = track(cat, Xs...; dims = dims)
-@grad function cat(Xs::TrackedArray{<:Any, D}...; dims) where {D}
+@grad function cat(Xs::AbstractArray...; dims)
     Xs_value = value.(Xs)
     return cat(Xs_value...; dims = dims), Δ -> begin
         start = ntuple(i -> 0, Val(ndims(Δ)))

--- a/src/derivatives/arrays.jl
+++ b/src/derivatives/arrays.jl
@@ -74,7 +74,7 @@ end
 
 @grad function hcat(xs::Union{TrackedVector, TrackedMatrix}...)
     xs_value = value.(xs)
-    out_value = hcat(xs_value...)
+    out_value = reduce(hcat,xs_value)
     function back(Δ)
         start = 0
         Δs = map(xs) do xsi

--- a/src/derivatives/linalg/arithmetic.jl
+++ b/src/derivatives/linalg/arithmetic.jl
@@ -183,10 +183,6 @@ end
     return out
 end
 
-
-const TrackedVector{V,D} = TrackedArray{V,D,1}
-const TrackedMatrix{V,D} = TrackedArray{V,D,2}
-
 for S1 in (:TrackedArray, :TrackedVector, :TrackedMatrix)
     for S2 in (:TrackedArray, :TrackedVector, :TrackedMatrix)
         @eval begin

--- a/src/tracked.jl
+++ b/src/tracked.jl
@@ -382,6 +382,7 @@ reshape_body = :(TrackedArray(reshape(value(t), dims), reshape(deriv(t), dims), 
 @eval Base.reshape(t::TrackedArray, dims::Tuple{Vararg{Int,N}}) where {N} = $reshape_body
 @eval Base.reshape(t::TrackedArray, dims::Int64...) = $reshape_body
 @eval Base.reshape(t::TrackedArray, dims::AbstractUnitRange...) = $reshape_body
+@eval Base.reshape(t::TrackedArray, dims::Colon...) = $reshape_body
 @eval Base.reshape(t::TrackedArray, dims::Union{AbstractUnitRange,Int64,Colon}...) = $reshape_body
 
 ####################

--- a/src/tracked.jl
+++ b/src/tracked.jl
@@ -335,7 +335,7 @@ function Base.getindex(t::TrackedArray, _inds::Union{Integer, Colon, AbstractArr
     end
     tp = tape(t)
     out = TrackedArray(value(t)[inds...], deriv(t)[inds...], tp)
-    record!(tp, SpecialInstruction, (getindex, Val(:genric)), (t, inds), out)
+    record!(tp, SpecialInstruction, (getindex, Val(:generic)), (t, inds), out)
     return out
 end
 @noinline function special_reverse_exec!(instruction::SpecialInstruction{<:Tuple{typeof(getindex), Val{:generic}}})

--- a/src/tracked.jl
+++ b/src/tracked.jl
@@ -382,7 +382,7 @@ reshape_body = :(TrackedArray(reshape(value(t), dims), reshape(deriv(t), dims), 
 @eval Base.reshape(t::TrackedArray, dims::Tuple{Vararg{Int,N}}) where {N} = $reshape_body
 @eval Base.reshape(t::TrackedArray, dims::Int64...) = $reshape_body
 @eval Base.reshape(t::TrackedArray, dims::AbstractUnitRange...) = $reshape_body
-@eval Base.reshape(t::TrackedArray, dims::Union{AbstractUnitRange,Int64}...) = $reshape_body
+@eval Base.reshape(t::TrackedArray, dims::Union{AbstractUnitRange,Int64,Colon}...) = $reshape_body
 
 ####################
 # `Real` Interface #

--- a/src/tracked.jl
+++ b/src/tracked.jl
@@ -382,7 +382,6 @@ reshape_body = :(TrackedArray(reshape(value(t), dims), reshape(deriv(t), dims), 
 @eval Base.reshape(t::TrackedArray, dims::Tuple{Vararg{Int,N}}) where {N} = $reshape_body
 @eval Base.reshape(t::TrackedArray, dims::Int64...) = $reshape_body
 @eval Base.reshape(t::TrackedArray, dims::AbstractUnitRange...) = $reshape_body
-@eval Base.reshape(t::TrackedArray, dims::Colon...) = $reshape_body
 @eval Base.reshape(t::TrackedArray, dims::Union{AbstractUnitRange,Int64,Colon}...) = $reshape_body
 
 ####################

--- a/test/derivatives/ArrayFunctionTests.jl
+++ b/test/derivatives/ArrayFunctionTests.jl
@@ -1,0 +1,67 @@
+using ReverseDiff: track, value, gradient, TrackedVector, TrackedMatrix, TrackedArray
+using Test
+
+@testset "fill" begin
+    v = fill(track(1), 3)
+    @test v isa TrackedArray
+    @test value(v) == fill(1, 3)
+    @test gradient(x -> sum(fill(x[1], 3)), rand(1)) == [3.0]
+end
+
+@testset "any & all" begin
+    @test all(iszero, track(zeros(3)))
+    @test !all(iszero, track([zeros(2); 1.0]))
+    @test !any(iszero, track(ones(3)))
+    @test any(iszero, track([ones(2); 0.0]))
+end
+
+function testcat(f, args::Tuple{Any, Any}, type, kwargs=NamedTuple())
+    x = f(track.(args)...; kwargs...)
+    @test x isa type
+    @test value(x) == f(args...; kwargs...)
+
+    x = f(track(args[1]), args[2]; kwargs...)
+    @test x isa type
+    @test value(x) == f(args...; kwargs...)
+
+    x = f(args[1], track(args[2]); kwargs...)
+    @test x isa type
+    @test value(x) == f(args...; kwargs...)
+
+    args = (args..., args...)
+    x = f(track.(args)...; kwargs...)
+    @test x isa type
+    @test value(x) == f(args...; kwargs...)
+end
+
+@testset "cat" begin
+    v = rand(3)
+    m = rand(3,3)
+    a = rand(3,3,3)
+    n = rand()
+
+    testcat(cat, (n, n), TrackedVector, (dims=1,))
+    testcat(cat, (n, n), TrackedMatrix, (dims=2,))
+    testcat(cat, (v, n), TrackedVector, (dims=1,))
+    testcat(cat, (n, v), TrackedVector, (dims=1,))
+
+    testcat(cat, (v, v), TrackedVector, (dims=1,))
+    testcat(cat, (v, v), TrackedMatrix, (dims=2,))
+    testcat(cat, (v, m), TrackedMatrix, (dims=2,))
+    testcat(cat, (m, v), TrackedMatrix, (dims=2,))
+
+    testcat(cat, (a, a), TrackedArray, (dims=1,))
+    testcat(cat, (a, a), TrackedArray, (dims=2,))
+    testcat(cat, (a, a), TrackedArray, (dims=3,))
+    testcat(cat, (a, m), TrackedArray, (dims=3,))
+
+    testcat(vcat, (n, n), TrackedVector)
+    testcat(vcat, (v, n), TrackedVector)
+    testcat(vcat, (n, v), TrackedVector)
+    testcat(vcat, (v, v), TrackedVector)
+
+    testcat(hcat, (n, n), TrackedMatrix)
+    testcat(hcat, (v, v), TrackedMatrix)
+    testcat(hcat, (v, m), TrackedMatrix)
+    testcat(hcat, (m, v), TrackedMatrix)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,10 @@ println("running ElementwiseTests...")
 t = @elapsed include(joinpath(TESTDIR, "derivatives/ElementwiseTests.jl"))
 println("done (took $t seconds).")
 
+println("running ArrayFunctionTests...")
+t = @elapsed include(joinpath(TESTDIR, "derivatives/ArrayFunctionTests.jl"))
+println("done (took $t seconds).")
+
 println("running GradientTests...")
 t = @elapsed include(joinpath(TESTDIR, "api/GradientTests.jl"))
 println("done (took $t seconds).")


### PR DESCRIPTION
This PR defines a few custom adjoints for some array functions. Currently, it gives a precompilation error in Julia 1.3 and a StackOverFlow in Julia 1.4 for what seems like a Julia bug triggered by https://github.com/JuliaDiff/ReverseDiff.jl/blob/mt/array_funcs/src/derivatives/arrays.jl#L40 and the next block. Commenting these 2 blocks, loading ReverseDiff and then calling:
```julia
using ReverseDiff: TrackedVecOrMat, track
Base.vcat(x::TrackedVecOrMat{T}, xs::AbstractVecOrMat{T}...) where T = track(vcat, x, xs...)
```
triggers the StackOverFlow in Julia 1.4 which again seems like a Julia bug?? I appreciate any help here. This PR is based on #123.