### PR TITLE
Support Callable struct

### DIFF
--- a/test/CallableStructTests.jl
+++ b/test/CallableStructTests.jl
@@ -1,0 +1,39 @@
+using ReverseDiff, Test
+
+# https://github.com/JuliaDiff/ReverseDiff.jl/issues/135
+
+struct Over{T} den::T end
+
+(o::Over)(x) = x ./ o.den
+
+(o::Over)(x::ReverseDiff.TrackedArray) = ReverseDiff.track(o, x)
+
+ReverseDiff.@grad function (o::Over)(x)
+    # abused gradient :/ but we can leverage it to test whether it come from custom grad or "normal over".
+    ReverseDiff.value(x) ./ o.den, Δ -> (Δ .* o.den,) 
+end
+
+
+struct Over2 end
+
+(o::Over2)(x) = x ./ 2
+
+(o::Over2)(x::ReverseDiff.TrackedArray) = ReverseDiff.track(o, x)
+
+ReverseDiff.@grad function (o::Over2)(x)
+    ReverseDiff.value(x) ./ 2, Δ -> (Δ .* 2,)
+end
+
+o3 = Over(3.)
+o2 = Over2()
+
+g3 = ReverseDiff.gradient([2., 1., 3.]) do x
+    sum(o3(x))
+end
+
+g2 = ReverseDiff.gradient([2., 1., 3.]) do x
+    sum(o2(x))
+end
+
+@test g3 == [3., 3., 3.]
+@test g2 == [2., 2., 2.]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,3 +45,7 @@ println("done (took $t seconds).")
 println("running ConfigTests...")
 t = @elapsed include(joinpath(TESTDIR, "api/ConfigTests.jl"))
 println("done (took $t seconds).")
+
+println("running CallableStructTests...")
+t = @elapsed include(joinpath(TESTDIR, "CallableStructTests.jl"))
+println("done (took $t seconds).")


### PR DESCRIPTION
Fix #135 

Though master branch (without this PR) local unit test will fail at 

```
running LinAlgTests...
  testing Array -> Number functions: `sum`...
  testing Array -> Number functions: `det`...
  testing Array -> Number functions: `mean`...
  testing Array -> Number functions: `#18`...
  testing Array -> Number functions: `#20`...
ERROR: LoadError: LoadError: MethodError: *(::LinearAlgebra.Adjoint{ReverseDiff.TrackedReal{Float64,Float64,ReverseDiff.TrackedArray{Float64,Float64,1,Array{Float64,1},Array{Float64,1}}},ReverseDiff.TrackedArray{Float64,Float64,1,Array{Float64,1},Array{Float64,1}}}, ::ReverseDiff.TrackedArray{Float64,Float64,1,Array{Float64,1},Array{Float64,1}}) is ambiguous. Candidates:
  *(u::LinearAlgebra.Adjoint{var"#s826",var"#s8261"} where var"#s8261"<:(AbstractArray{T,1} where T) where var"#s826"<:Number, v::AbstractArray{var"#s825",1} where var"#s825"<:Number) in LinearAlgebra at /home/yiyuezhuo/Downloads/julia-1.5.0/share/julia/stdlib/v1.5/LinearAlgebra/src/adjtrans.jl:283
  *(A::LinearAlgebra.Adjoint{var"#s92",var"#s91"} where var"#s91"<:(ReverseDiff.TrackedArray{T,D,1,VA,DA}where DA where VA) where var"#s92", B::ReverseDiff.TrackedArray{T,D,1,VA,DA} where DA where VA) where {T<:Real, D} in ReverseDiff at /home/yiyuezhuo/.julia/dev/ReverseDiff/src/derivatives/linalg/arithmetic.jl:254
Possible fix, define
  *(::LinearAlgebra.Adjoint{var"#s92",var"#s91"} where var"#s91"<:(ReverseDiff.TrackedArray{T,D,1,VA,DA} where DA where VA) where var"#s92"<:Number, ::ReverseDiff.TrackedArray{T,D,1,VA,DA} where DA where VA) where {T<:Real, D}
```

This PR doesn't try to solve this problem, so CI will fail I guess. But my local unit test at least failed at same location as master branch while added unit test `CallableStructTests.jl` will pass:

```julia
using ReverseDiff, Test

# https://github.com/JuliaDiff/ReverseDiff.jl/issues/135

struct Over{T} den::T end

(o::Over)(x) = x ./ o.den

(o::Over)(x::ReverseDiff.TrackedArray) = ReverseDiff.track(o, x)

ReverseDiff.@grad function (o::Over)(x)
    # abused gradient :/ but we can leverage it to test whether it come from custom grad or "normal over".
    ReverseDiff.value(x) ./ o.den, Δ -> (Δ .* o.den,) 
end


struct Over2 end

(o::Over2)(x) = x ./ 2

(o::Over2)(x::ReverseDiff.TrackedArray) = ReverseDiff.track(o, x)

ReverseDiff.@grad function (o::Over2)(x)
    ReverseDiff.value(x) ./ 2, Δ -> (Δ .* 2,)
end

o3 = Over(3.)
o2 = Over2()

g3 = ReverseDiff.gradient([2., 1., 3.]) do x
    sum(o3(x))
end

g2 = ReverseDiff.gradient([2., 1., 3.]) do x
    sum(o2(x))
end

@test g3 == [3., 3., 3.]
@test g2 == [2., 2., 2.]
```