### PR TITLE
Implement `view`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReverseDiff"
 uuid = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
-version = "1.5.0"
+version = "1.6.0"
 
 [deps]
 DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"

--- a/src/tracked.jl
+++ b/src/tracked.jl
@@ -385,6 +385,10 @@ reshape_body = :(TrackedArray(reshape(value(t), dims), reshape(deriv(t), dims), 
 @eval Base.reshape(t::TrackedArray, dims::Colon...) = $reshape_body
 @eval Base.reshape(t::TrackedArray, dims::Union{AbstractUnitRange,Int64,Colon}...) = $reshape_body
 
+Base.@propagate_inbounds function Base.view(t::TrackedArray, inds...)
+    return TrackedArray(view(value(t), inds...), view(deriv(t), inds...), tape(t))
+end
+
 ####################
 # `Real` Interface #
 ####################

--- a/test/TrackedTests.jl
+++ b/test/TrackedTests.jl
@@ -1,7 +1,7 @@
 module TrackedTests
 
 using ReverseDiff, Test
-using ReverseDiff: TrackedReal, TrackedArray
+using ReverseDiff: TrackedReal, TrackedArray, TrackedVector, TrackedMatrix
 
 include(joinpath(dirname(@__FILE__), "utils.jl"))
 
@@ -697,6 +697,26 @@ empty!(tp)
 @test Base.copy(ta) === ta
 
 @test all(samefields.(ta, copyto!(similar(ta), ta)))
+
+ta_sub = view(ta, :, :)
+@test ta_sub isa TrackedMatrix
+@test size(ta_sub) == (3, 3)
+
+ta_sub = view(ta, :, 1:2)
+@test ta_sub isa TrackedMatrix
+@test size(ta_sub) == (3, 2)
+
+# violates assertion `IndexStyle(value) === IndexLinear()``
+@test_throws AssertionError view(ta, 2:3, :)
+@test_throws AssertionError view(ta, 2:3, 1:2)
+
+ta_sub = view(ta, 2:6)
+@test ta_sub isa TrackedVector
+@test size(ta_sub) == (5,)
+
+ta_sub = view(ta, :)
+@test ta_sub isa TrackedVector
+@test size(ta_sub) == (9,)
 
 ####################
 # `Real` Interface #


### PR DESCRIPTION
Currently, `track` + a custom gradient implementation return a gradient of zero when called with a `SubArray`. After a lot of debugging, I was able to condense one of the problems in https://github.com/TuringLang/DistributionsAD.jl/pull/151 to the following MWE:
```julia
julia> using ReverseDiff

julia> f(x::AbstractVector) = sum(abs2, x)

julia> f(x::AbstractVector{<:ReverseDiff.TrackedReal}) = ReverseDiff.track(f, x)

julia> ReverseDiff.@grad function f(x::AbstractVector{<:ReverseDiff.TrackedReal})
           xv = ReverseDiff.value(x)
           y = f(xv)
           function f_pullback(Δ::Real)
               return ((2 * Δ) .* xv,)
           end
           return y, f_pullback
       end

julia> A = rand(10, 20);

julia> ReverseDiff.gradient(A) do x
           sum(i -> sum(abs2, view(x, :, i)), axes(x, 2))
       end ≈ 2 * A
true

julia> ReverseDiff.gradient(A) do x
           sum(i -> f(x[:, i]), axes(x, 2))
       end ≈ 2 * A
true

julia> ReverseDiff.gradient(A) do x
           sum(i -> f(view(x, :, i)), axes(x, 2))
       end ≈ 2 * A
false

julia> all(
           iszero,
           ReverseDiff.gradient(A) do x
               sum(i -> f(view(x, :, i)), axes(x, 2))
           end,
       )
true
```
I.e., the gradient can be computed correctly with `view` if `track` is not used, and it can be computed correctly with the custom gradient without `view`. However, the gradients are zero if `view` is used together with a custom gradient.

This PR fixes the example above by implementing `view` for TrackedArray such that it returns a `TrackedArray` instead of a `SubArray` (as currently done). This is consistent with the definitions of `getindex` and `reshape`. However, it is a bit unfortunate that it does only work if `view` would return an array with `IndexLinear` indexing style - apparently an assertion in the implementation of `TrackedArray` only allows this indexing style.

Therefore I wonder if maybe it would be better to fix the problem by adding some special cases for `SubArray` in the `track`ing pipeline. Since I am not familiar with the details there, I chose to implement `view`. In general, `view` is not guaranteed to return a `SubArray` (e.g. `FillArray`s return `FillArray`s and `Range`s `Range`s), so special casing on `SubArray` would not fix all use cases of `view`.