### PR TITLE
Fix `Base.isapprox` for `TrackedReal`

### DIFF
--- a/src/tracked.jl
+++ b/src/tracked.jl
@@ -426,6 +426,8 @@ Base.round(::Type{R}, t::TrackedReal) where {R<:Real} = round(R, value(t))
 Base.oneunit(t::TrackedReal) = one(t)
 Base.oneunit(::Type{T}) where {T<:TrackedReal} = one(T)
 
+Base.rtoldefault(::Type{T}) where {T<:TrackedReal} = sqrt(eps(T))
+
 ################
 # track/track! #
 ################

--- a/test/TrackedTests.jl
+++ b/test/TrackedTests.jl
@@ -741,6 +741,14 @@ tr_rand = rand(MersenneTwister(1), TrackedReal{Int,Float64,Nothing})
 @test round(tr_float) === round(v_float)
 @test round(Int, tr_float) === round(Int, v_float)
 
+f = rand()
+tr1 = ReverseDiff.TrackedReal(f, rand(), tp)
+tr2 = ReverseDiff.TrackedReal(2*f, rand(), tp)
+tr3 = ReverseDiff.TrackedReal(f + eps(f), rand(), tp)
+
+@test isapprox(tr1, tr2) == false
+@test isapprox(tr1, tr3) == true
+
 ################
 # track/track! #
 ################


### PR DESCRIPTION
The `Base.isapprox` function relies on `Base.rtoldefault` to return an acceptable margin of error for inexact comparisons. If the default implementation for types descending from `AbstractFloat` returns `sqrt(eps(T))`, the one for types descending from `Real` simply returns 0.

As `TrackedReal` descends from `Real` and not `AbstractFloat`, a custom `Base.rtoldefault` implementation returning `sqrt(eps(T))` ensures that `iscompare` behaves correctly for `TrackedReal` approximative comparisons.

Fixes #165 