### PR TITLE
Add support for `AbstractArray{<:TrackedReal}`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReverseDiff"
 uuid = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
-version = "1.5.0"
+version = "1.6.0"
 
 [deps]
 DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -238,7 +238,7 @@ macro grad(expr)
     end |> esc
 end
 _add_to_deriv!(d1, d2) = nothing
-function _add_to_deriv!(d1::Union{TrackedReal, TrackedArray}, d2)
+function _add_to_deriv!(d1::Union{TrackedReal, AbstractArray{<:TrackedReal}}, d2)
     increment_deriv!(d1, d2)
 end
 function getargs_expr(args_with_types)


### PR DESCRIPTION
This is an alternative to https://github.com/JuliaDiff/ReverseDiff.jl/pull/164, as suggested by @mohamed82008. It fixes the example therein by adding support for `AbstractArray{<:TrackedReal}` instead of changing the output of `view` to `TrackedArray` instead of `SubArray`. Therefore it should add support for other array wrappers as well (untested).