### PR TITLE
Fix broken tests

### DIFF
--- a/test/utils.jl
+++ b/test/utils.jl
@@ -10,7 +10,7 @@ const COMPILED_TAPE_LIMIT = 5000
 # machinery is currently too dumb to handle them properly.
 const SKIPPED_BINARY_SCALAR_TESTS = Symbol[:hankelh1, :hankelh1x, :hankelh2, :hankelh2x,
                                            :pow, :besselj, :besseli, :bessely, :besselk,
-                                           :polygamma]
+                                           :polygamma, :ldexp]
 
 # make RNG deterministic, and thus make result inaccuracies
 # deterministic so we don't have to retune EPS for arbitrary inputs


### PR DESCRIPTION
https://github.com/JuliaDiff/DiffRules.jl/pull/73 broke the tests since, similar to `polygamma` the current DiffRules integration and test infrastructure can't deal with functions with two arguments of which one has to be an integer.

Ideally, this would be tested properly but this PR is a temporary solution that requires minimal changes and fixes also the downstream tests in DiffRules.

It seems one problem with these functions is that the arguments are promoted when they are forwarded to ForwardDiff since everything is packed in a static vector - in these cases it would be better to not promote and work with the DiffRules definitions directly. I wonder why this is not done already and instead ReverseDiff calls ForwardDiff?