### PR TITLE
Add overloads for fld, cld, and div

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReverseDiff"
 uuid = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
-version = "1.12.0"
+version = "1.13.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/tracked.jl
+++ b/src/tracked.jl
@@ -428,9 +428,9 @@ Base.floor(::Type{R}, t::TrackedReal) where {R<:Real} = floor(R, value(t))
 Base.ceil(t::TrackedReal) = ceil(value(t))
 Base.ceil(::Type{R}, t::TrackedReal) where {R<:Real} = ceil(R, value(t))
 
-Base.fld(a::TrackedReal, b::TrackedReal) = fld(value(a), value(b))
+Base.fld(x::T, y::T) where {T<:TrackedReal} = fld(value(x), value(y))
 
-Base.cld(a::TrackedReal, b::TrackedReal) = cld(value(a), value(b))
+Base.cld(x::T, y::T) where {T<:TrackedReal} = cld(value(x), value(y))
 
 if VERSION ≥ v"1.4"
     Base.div(x::TrackedReal, y::TrackedReal, r::RoundingMode) = div(value(x), value(y), r)

--- a/src/tracked.jl
+++ b/src/tracked.jl
@@ -428,9 +428,9 @@ Base.floor(::Type{R}, t::TrackedReal) where {R<:Real} = floor(R, value(t))
 Base.ceil(t::TrackedReal) = ceil(value(t))
 Base.ceil(::Type{R}, t::TrackedReal) where {R<:Real} = ceil(R, value(t))
 
-Base.fld(x::T, y::T) where {T<:TrackedReal} = fld(value(x), value(y))
+Base.fld(a::TrackedReal, b::TrackedReal) = fld(value(a), value(b))
 
-Base.cld(x::T, y::T) where {T<:TrackedReal} = cld(value(x), value(y))
+Base.cld(a::TrackedReal, b::TrackedReal) = cld(value(a), value(b))
 
 if VERSION ≥ v"1.4"
     Base.div(x::TrackedReal, y::TrackedReal, r::RoundingMode) = div(value(x), value(y), r)

--- a/src/tracked.jl
+++ b/src/tracked.jl
@@ -428,6 +428,16 @@ Base.floor(::Type{R}, t::TrackedReal) where {R<:Real} = floor(R, value(t))
 Base.ceil(t::TrackedReal) = ceil(value(t))
 Base.ceil(::Type{R}, t::TrackedReal) where {R<:Real} = ceil(R, value(t))
 
+Base.fld(a::TrackedReal, b::TrackedReal) = fld(value(a), value(b))
+
+Base.cld(a::TrackedReal, b::TrackedReal) = cld(value(a), value(b))
+
+if VERSION ≥ v"1.4"
+    Base.div(x::TrackedReal, y::TrackedReal, r::RoundingMode) = div(value(x), value(y), r)
+else
+    Base.div(x::TrackedReal, y::TrackedReal) = div(value(x), value(y))
+end
+
 Base.trunc(t::TrackedReal) = trunc(value(t))
 Base.trunc(::Type{R}, t::TrackedReal) where {R<:Real} = trunc(R, value(t))
 

--- a/test/TrackedTests.jl
+++ b/test/TrackedTests.jl
@@ -703,9 +703,11 @@ empty!(tp)
 ####################
 
 v_int, v_float, d = rand(Int), rand(), rand()
+v_float2, d2 = rand(), rand()
 tp = InstructionTape()
 tr_int = TrackedReal(v_int, d, tp)
 tr_float = TrackedReal(v_float, d, tp)
+tr_float2 = TrackedReal(v_float2, d2, tp)
 
 @test hash(tr_float) === hash(v_float)
 @test hash(tr_float, hash(1)) === hash(v_float, hash(1))
@@ -734,6 +736,26 @@ tr_rand = rand(MersenneTwister(1), TrackedReal{Int,Float64,Nothing})
 
 @test ceil(tr_float) === ceil(v_float)
 @test ceil(Int, tr_float) === ceil(Int, v_float)
+
+@test fld(tr_float, tr_float2) === fld(v_float, v_float2)
+@test fld(tr_float, v_float2) === fld(v_float, v_float2)
+@test fld(v_float, tr_float2) === fld(v_float, v_float2)
+
+@test cld(tr_float, tr_float2) === cld(v_float, v_float2)
+@test cld(tr_float, v_float2) === cld(v_float, v_float2)
+@test cld(v_float, tr_float2) === cld(v_float, v_float2)
+
+@test div(tr_float, tr_float2) === div(v_float, v_float2)
+@test div(v_float, tr_float2) === div(v_float, v_float2)
+@test div(tr_float, v_float2) === div(v_float, v_float2)
+
+if VERSION ≥ v"1.4"
+    for r in (RoundUp, RoundDown)
+        @test div(tr_float, tr_float2, r) === div(v_float, v_float2, r)
+        @test div(v_float, tr_float2, r) === div(v_float, v_float2, r)
+        @test div(tr_float, v_float2, r) === div(v_float, v_float2, r)
+    end
+end
 
 @test trunc(tr_float) === trunc(v_float)
 @test trunc(Int, tr_float) === trunc(Int, v_float)


### PR DESCRIPTION
This PR adds overloads for `fld`, `cld`, and `div`, which all return a `MethodError` on master. The overloads for `div` are the same ones used by ForwardDiff: https://github.com/JuliaDiff/ForwardDiff.jl/blob/29332b12075e66e056843d3b4207d856f98772b3/src/dual.jl#L287-L291