### PR TITLE
fix for issue #139 - to allow other Int subtypes to this getindex

### DIFF
--- a/src/tracked.jl
+++ b/src/tracked.jl
@@ -280,7 +280,7 @@ Base.promote_rule(::Type{TrackedReal{V1,D1,O1}}, ::Type{TrackedReal{V2,D2,O2}}) 
 # AbstractArray Interface #
 ###########################
 
-Base.getindex(t::TrackedArray, i::Int) = TrackedReal(value(t)[i], deriv(t)[i], tape(t), i, t)
+Base.getindex(t::TrackedArray, i::Integer) = TrackedReal(value(t)[i], deriv(t)[i], tape(t), i, t)
 
 colon2range(s, i) = i
 colon2range(s, ::Colon) = s


### PR DESCRIPTION
Fix for the following error

```julia 
ERROR: MethodError: no method matching ReverseDiff.TrackedArray(::Float64, ::Float64, ::Vector{ReverseDiff.AbstractInstruction})
Closest candidates are:
 ReverseDiff.TrackedArray(::AbstractArray{V, N}, ::AbstractArray{D, N}, ::Vector{ReverseDiff.AbstractInstruction}) where {V, D, N} at ~/.julia/packages/ReverseDiff/c21a6/src/tracked.jl:83
Stacktrace:
  [1] getindex(t::ReverseDiff.TrackedArray{Float64, Float64, 1, Vector{Float64}, Vector{Float64}}, _inds::Int32)
```

so that it accesses `Base.getindex(t::TrackedArray, i::Int) = TrackedReal(value(t)[i], deriv(t)[i], tape(t), i, t)` instead of `Base.getindex(t::TrackedArray, _inds::Union{Integer, Colon, AbstractArray{<:Integer}}...)`. `Base.getindex(t::TrackedArray, i::Int) = TrackedReal(value(t)[i], deriv(t)[i], tape(t), i, t)` resolves the error!

I could also change it from `Integer` to `Union{Int32,Int64}` if some thing else breaks in relation to this