### PR TITLE
Fix `getindex`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReverseDiff"
 uuid = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
-version = "1.14.0"
+version = "1.14.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
This PR fixes `getindex` for non-`Int` indices (fixes #139), removes undesired definitions for `getindex` caused by Varargs, adds `@propagate_inbounds` annotations, and adds tests.