### PR TITLE
Relax linear indexing requirement _slightly_

### DIFF
--- a/src/tracked.jl
+++ b/src/tracked.jl
@@ -67,6 +67,8 @@ TrackedReal(v::V, a::D, tp::InstructionTape = NULL_TAPE) where {V,D} = TrackedRe
 # TrackedArray #
 #--------------#
 
+supports_linear_indexing(x) = IndexStyle(x) === IndexLinear()
+
 struct TrackedArray{V,D,N,VA,DA} <: AbstractArray{TrackedReal{V,D,TrackedArray{V,D,N,VA,DA}},N}
     value::VA
     deriv::DA
@@ -74,7 +76,7 @@ struct TrackedArray{V,D,N,VA,DA} <: AbstractArray{TrackedReal{V,D,TrackedArray{V
     function TrackedArray{V,D,N,VA,DA}(value::AbstractArray{V,N},
                                        deriv::AbstractArray{D,N},
                                        tape::InstructionTape) where {V,D,N,VA,DA}
-        @assert IndexStyle(value) === IndexLinear()
+        @assert supports_linear_indexing(value)
         @assert size(value) === size(deriv)
         return new{V,D,N,VA,DA}(value, deriv, tape)
     end


### PR DESCRIPTION
Currently `TrackedArray` requires the input to satisfy `IndexStyle(x) === IndexLinear()` since ReverseDiff currently only has the capability of tracking, well, arrays supporting linear indexing.

But _supporting_ linear indexing and having `IndexStyle(x) === IndexLinear()` are, IIUC, two different things: you can support linear indexing while still having `IndexStyle(x) === IndexCartesian()`, i.e. linear indexing is not the most efficient indexing.

For example, `DifferentialEquations.DESolution` supports linear indexing but has `IndexStyle(x) === IndexCartesian()`.

Currently, this means that DiffEq has to hack around this constraint by converting into a `Matrix`, completely losing all the information related to the `DESolution`. 

This PR adds a method `supports_linear_indexing` which gives arrays such as `DESolution` a way to tell ReverseDiff that it supports linear indexing even though it's not maybe the most efficient way to index in the array.

I honestly don't know 100% if this is the way to go, but it seems to do the trick locally (and seem to compute the correct gradients) so figured I'd make a PR to maybe at least get a discussion going.