### PR TITLE
Handle matrix times matrix = vector case

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReverseDiff"
 uuid = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
-version = "1.14.5"
+version = "1.14.6"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/derivatives/linalg/arithmetic.jl
+++ b/src/derivatives/linalg/arithmetic.jl
@@ -270,11 +270,13 @@ end
 # a * b
 
 function reverse_mul!(output, output_deriv, a, b, a_tmp, b_tmp)
-    istracked(a) && increment_deriv!(a, mul!(a_tmp, output_deriv, transpose(value(b))))
-    istracked(b) && increment_deriv!(b, mul!(b_tmp, transpose(value(a)), output_deriv))
-end
-function reverse_mul!(output, output_deriv::AbstractMatrix, a, b::AbstractMatrix, a_tmp::AbstractVector, b_tmp)
-    istracked(a) && increment_deriv!(a, mul!(reshape(a_tmp, :, 1), output_deriv, transpose(value(b))))
+    if istracked(a)
+        if a_tmp isa AbstractVector && b isa AbstractMatrix
+            increment_deriv!(a, mul!(reshape(a_tmp, :, 1), output_deriv, transpose(value(b))))
+        else
+            increment_deriv!(a, mul!(a_tmp, output_deriv, transpose(value(b))))
+        end
+    end
     istracked(b) && increment_deriv!(b, mul!(b_tmp, transpose(value(a)), output_deriv))
 end
 

--- a/src/derivatives/linalg/arithmetic.jl
+++ b/src/derivatives/linalg/arithmetic.jl
@@ -272,6 +272,10 @@ end
 function reverse_mul!(output, output_deriv, a, b, a_tmp, b_tmp)
     if istracked(a)
         if a_tmp isa AbstractVector && b isa AbstractMatrix
+            # this branch is required for scalar-valued functions that
+            # involve outer-products of vectors, for such functions, the target
+            # a_temp is a vector, but when b is a matrix, we cannot multiply into a vector,
+            # so need to reshape memory to look like matrix (see PositiveFactorizations.jl)
             increment_deriv!(a, mul!(reshape(a_tmp, :, 1), output_deriv, transpose(value(b))))
         else
             increment_deriv!(a, mul!(a_tmp, output_deriv, transpose(value(b))))
@@ -285,8 +289,14 @@ for (f, F) in ((:transpose, :Transpose), (:adjoint, :Adjoint))
         # a * f(b)
         function reverse_mul!(output, output_deriv, a, b::$F, a_tmp, b_tmp)
             _b = ($f)(b)
-            istracked(a) && increment_deriv!(a, mul!(a_tmp, output_deriv, mulargvalue(b)))
-            istracked(_b) && increment_deriv!(_b, ($f)(mul!(b_tmp, ($f)(output_deriv), value(a))))
+            if istracked(a)
+                if a_tmp isa AbstractVector
+                    increment_deriv!(a, mul!(reshape(a_tmp, :, 1), output_deriv, mulargvalue(_b)))
+                else
+                    increment_deriv!(a, mul!(a_tmp, output_deriv, mulargvalue(b)))
+                end
+            end
+            istracked(_b) && increment_deriv!(_b, ($f)(mul!(($f)(b_tmp), ($f)(output_deriv), value(a))))
         end
            # f(a) * b
         function reverse_mul!(output, output_deriv, a::$F, b, a_tmp, b_tmp)

--- a/src/derivatives/linalg/arithmetic.jl
+++ b/src/derivatives/linalg/arithmetic.jl
@@ -273,6 +273,10 @@ function reverse_mul!(output, output_deriv, a, b, a_tmp, b_tmp)
     istracked(a) && increment_deriv!(a, mul!(a_tmp, output_deriv, transpose(value(b))))
     istracked(b) && increment_deriv!(b, mul!(b_tmp, transpose(value(a)), output_deriv))
 end
+function reverse_mul!(output, output_deriv::AbstractMatrix, a, b::AbstractMatrix, a_tmp::AbstractVector, b_tmp)
+    istracked(a) && increment_deriv!(a, mul!(reshape(a_tmp, :, 1), output_deriv, transpose(value(b))))
+    istracked(b) && increment_deriv!(b, mul!(b_tmp, transpose(value(a)), output_deriv))
+end
 
 for (f, F) in ((:transpose, :Transpose), (:adjoint, :Adjoint))
     @eval begin

--- a/test/api/GradientTests.jl
+++ b/test/api/GradientTests.jl
@@ -188,12 +188,22 @@ for f in DiffTests.VECTOR_TO_NUMBER_FUNCS
 end
 
 # PR #227
-function norm_hermitian(v)
-    A = I - 2 * v * v'
-    return norm(A' * A)
-end
-test_println("VECTOR_TO_NUMBER_FUNCS", norm_hermitian)
-test_unary_gradient(norm_hermitian, rand(5))
+norm_hermitian1(v) = (A = I - 2 * v * v'; norm(A' * A))
+norm_hermitian2(v) = (A = I - 2 * v * transpose(v); norm(transpose(A) * A))
+norm_hermitian3(v) = (A = I - 2 * v * collect(v'); norm(collect(A') * A))
+norm_hermitian4(v) = (A = I - 2 * v * v'; norm(transpose(A) * A))
+norm_hermitian5(v) = (A = I - 2 * v * transpose(v); norm(A' * A))
+
+test_println("VECTOR_TO_NUMBER_FUNCS", norm_hermitian1)
+test_unary_gradient(norm_hermitian1, rand(5))
+test_println("VECTOR_TO_NUMBER_FUNCS", norm_hermitian2)
+test_unary_gradient(norm_hermitian2, rand(5))
+test_println("VECTOR_TO_NUMBER_FUNCS", norm_hermitian3)
+test_unary_gradient(norm_hermitian3, rand(5))
+test_println("VECTOR_TO_NUMBER_FUNCS", norm_hermitian4)
+test_unary_gradient(norm_hermitian4, rand(5))
+test_println("VECTOR_TO_NUMBER_FUNCS", norm_hermitian5)
+test_unary_gradient(norm_hermitian5, rand(5))
 
 for f in DiffTests.TERNARY_MATRIX_TO_NUMBER_FUNCS
     test_println("TERNARY_MATRIX_TO_NUMBER_FUNCS", f)

--- a/test/api/GradientTests.jl
+++ b/test/api/GradientTests.jl
@@ -1,6 +1,6 @@
 module GradientTests
 
-using DiffTests, ForwardDiff, ReverseDiff, Test
+using DiffTests, ForwardDiff, ReverseDiff, Test, LinearAlgebra
 
 include(joinpath(dirname(@__FILE__), "../utils.jl"))
 

--- a/test/api/GradientTests.jl
+++ b/test/api/GradientTests.jl
@@ -193,8 +193,10 @@ norm_hermitian2(v) = (A = I - 2 * v * transpose(v); norm(transpose(A) * A))
 norm_hermitian3(v) = (A = I - 2 * v * collect(v'); norm(collect(A') * A))
 norm_hermitian4(v) = (A = I - 2 * v * v'; norm(transpose(A) * A))
 norm_hermitian5(v) = (A = I - 2 * v * transpose(v); norm(A' * A))
+norm_hermitian6(v) = (A = (v'v)*I - 2 * v * v'; norm(A' * A))
 
-for f in (norm_hermitian1, norm_hermitian2, norm_hermitian3, norm_hermitian4, norm_hermitian5)
+for f in (norm_hermitian1, norm_hermitian2, norm_hermitian3,
+            norm_hermitian4, norm_hermitian5, norm_hermitian6)
     test_println("VECTOR_TO_NUMBER_FUNCS", f)
     test_unary_gradient(f, rand(5))
 end

--- a/test/api/GradientTests.jl
+++ b/test/api/GradientTests.jl
@@ -187,11 +187,13 @@ for f in DiffTests.VECTOR_TO_NUMBER_FUNCS
     test_unary_gradient(f, rand(5))
 end
 
-vec_to_hermitian = (v) -> begin A = I - 2 * v * collect(v'); A = collect(A') * A end;
-for f in (y -> norm(vec_to_hermitian(y)),)
-    test_println("VECTOR_TO_NUMBER_FUNCS", f)
-    test_unary_gradient(f, rand(5))
+# PR #227
+function norm_hermitian(v)
+    A = I - 2 * v * v'
+    return norm(A' * A)
 end
+test_println("VECTOR_TO_NUMBER_FUNCS", norm_hermitian)
+test_unary_gradient(norm_hermitian, rand(5))
 
 for f in DiffTests.TERNARY_MATRIX_TO_NUMBER_FUNCS
     test_println("TERNARY_MATRIX_TO_NUMBER_FUNCS", f)

--- a/test/api/GradientTests.jl
+++ b/test/api/GradientTests.jl
@@ -187,6 +187,12 @@ for f in DiffTests.VECTOR_TO_NUMBER_FUNCS
     test_unary_gradient(f, rand(5))
 end
 
+vec_to_hermitian = (v) -> begin A = I - 2 * v * collect(v'); A = collect(A') * A end;
+for f in (y -> norm(vec_to_hermitian(y)),)
+    test_println("VECTOR_TO_NUMBER_FUNCS", f)
+    test_unary_gradient(f, rand(5))
+end
+
 for f in DiffTests.TERNARY_MATRIX_TO_NUMBER_FUNCS
     test_println("TERNARY_MATRIX_TO_NUMBER_FUNCS", f)
     test_ternary_gradient(f, rand(5, 5), rand(5, 5), rand(5, 5))

--- a/test/api/GradientTests.jl
+++ b/test/api/GradientTests.jl
@@ -194,16 +194,10 @@ norm_hermitian3(v) = (A = I - 2 * v * collect(v'); norm(collect(A') * A))
 norm_hermitian4(v) = (A = I - 2 * v * v'; norm(transpose(A) * A))
 norm_hermitian5(v) = (A = I - 2 * v * transpose(v); norm(A' * A))
 
-test_println("VECTOR_TO_NUMBER_FUNCS", norm_hermitian1)
-test_unary_gradient(norm_hermitian1, rand(5))
-test_println("VECTOR_TO_NUMBER_FUNCS", norm_hermitian2)
-test_unary_gradient(norm_hermitian2, rand(5))
-test_println("VECTOR_TO_NUMBER_FUNCS", norm_hermitian3)
-test_unary_gradient(norm_hermitian3, rand(5))
-test_println("VECTOR_TO_NUMBER_FUNCS", norm_hermitian4)
-test_unary_gradient(norm_hermitian4, rand(5))
-test_println("VECTOR_TO_NUMBER_FUNCS", norm_hermitian5)
-test_unary_gradient(norm_hermitian5, rand(5))
+for f in (norm_hermitian1, norm_hermitian2, norm_hermitian3, norm_hermitian4, norm_hermitian5)
+    test_println("VECTOR_TO_NUMBER_FUNCS", f)
+    test_unary_gradient(f, rand(5))
+end
 
 for f in DiffTests.TERNARY_MATRIX_TO_NUMBER_FUNCS
     test_println("TERNARY_MATRIX_TO_NUMBER_FUNCS", f)

--- a/test/derivatives/LinAlgTests.jl
+++ b/test/derivatives/LinAlgTests.jl
@@ -223,8 +223,11 @@ for f in (
     test_arr2num(f, x, tp)
 end
 
+vec_to_hermitian = (v) -> begin A = I - 2 * v * collect(v'); A = collect(A') * A end;
+
 for f in (
     y -> vec(y)' * Matrix{Float64}(I, length(y), length(y)) * vec(y),
+    y -> norm(vec_to_hermitian(y)),
 )
     test_println("Array -> Number functions", f)
     test_arr2num(f, x, tp, ignore_tape_length=true)

--- a/test/derivatives/LinAlgTests.jl
+++ b/test/derivatives/LinAlgTests.jl
@@ -223,11 +223,15 @@ for f in (
     test_arr2num(f, x, tp)
 end
 
-vec_to_hermitian = (v) -> begin A = I - 2 * v * collect(v'); A = collect(A') * A end;
+# PR #227
+function norm_hermitian(v)
+    A = I - 2 * v * v'
+    return norm(A' * A)
+end
 
 for f in (
     y -> vec(y)' * Matrix{Float64}(I, length(y), length(y)) * vec(y),
-    y -> norm(vec_to_hermitian(y)),
+    norm_hermitian,
 )
     test_println("Array -> Number functions", f)
     test_arr2num(f, x, tp, ignore_tape_length=true)


### PR DESCRIPTION
This "fixes" some weird behavior in the multiplication code. It occurred in https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/8a3027b_vs_960870e/PositiveFactorizations.primary.log PositiveFactorizations.jl. In their case, they want to multiply a matrix by the transpose of a row matrix (i.e., vector-like) into a vector. "By chance", this works out from the pov of dimensions, but from the pov of types having such a `mul!` method is weird and we may not wish to continue to support this (https://github.com/JuliaLang/julia/pull/49521#discussion_r1178114739). To make this package (and PositiveFactorizations.jl) run smoothly across (past and upcoming) versions, I proposed to simply catch that case and reshape the output vector to a matrix. In fact, this may even turn out to be advantageous in terms of performance, because that strange method in LinearAlgebra.jl calls `generic_matmatmul!`, for arguments matching the following signature:

```julia
mul!(::Vector{Float64}, ::Matrix{Float64}, ::Transpose{Float64, Matrix{Float64}}, ::Bool, ::Bool)
```

Once we reshape the vector to a matrix, this would go down the BLAS route!