### PR TITLE
(Temporarily) fix stable docs link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ReverseDiff
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliadiff.org/ReverseDiff.jl/stable)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliadiff.org/ReverseDiff.jl/)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliadiff.org/ReverseDiff.jl/dev)
 [![Build status](https://github.com/JuliaDiff/ReverseDiff.jl/workflows/CI/badge.svg)](https://github.com/JuliaDiff/ReverseDiff.jl/actions)
 [![codecov.io](https://codecov.io/github/JuliaDiff/ReverseDiff.jl/coverage.svg?branch=master)](https://codecov.io/github/JuliaDiff/ReverseDiff.jl?branch=master)


### PR DESCRIPTION
#246 pointed out that the docs are not correctly deployed. Unfortunately, this is still the case so in the meantime a quick "bandaid" fix which makes the stable docs accessible is just to change the stable docs link.

Right now the stable docs are hard to find unless you know that removing `/stable` from the url goes there.

Apologies if this is the wrong fix to the problem, it was just bugging me.