### PR TITLE
Document the interaction behaviour of `@grad` and `compile`.

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -174,7 +174,12 @@ end
         xv = ReverseDiff.value(x)
         return dot(xv, xv), Δ -> (Δ * 2 * xv,)
     end
-The `@grad` macro provides a way for the users to define custom adjoints for single-output functions wrt to their input numbers or arrays.
+The `@grad` macro provides a way for the users to define custom adjoints for
+single-output functions wrt to their input numbers or arrays. The function that
+`@grad` is applied to should return a two-element tuple containing the primal
+value and the adjoint function. Note that if an adjoint function is compiled
+using `compile`, any variables defined outside of the returned adjoint function
+are "frozen" at their compiled values.
 """
 macro grad(expr)
     d = MacroTools.splitdef(expr)


### PR DESCRIPTION
### TLDR:
This PR adds documentation to `@grad` that specifies what the `@grad`ed function should return, and documents that any variables defined outside of the returned adjoint function have their values `frozen` to their compiled ones.

### Context:
In [this discussion](https://github.com/JuliaDiff/ReverseDiff.jl/issues/234#issuecomment-1591127222) from [issue #243](https://github.com/JuliaDiff/ReverseDiff.jl/issues/234) I fumbled my way through working out how `@grad` functions in relation to `compile`.  Unsurprisingly to anyone who understands adjoints, I found out that any intermediate variables defined in the body of the function could be _used_ but not _updated_ when the gradient is compiled with `compile`.

This PR is just a bit of documentation added to the unexported macro `@grad` so that anyone else who dives into ReverseDiff might have an easier time concretely understanding the expected effects of `compile`.

Any suggestions on changes to language or wording are more than welcome.