### PR TITLE
Add AbstractIrrational to list of types for TrackedReal promote_rule definitions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,6 +24,7 @@ DiffRules = "1.4"
 DiffTests = "< 0.1.2"
 ForwardDiff = "0.10"
 FunctionWrappers = "1"
+IrrationalConstants = "0.2"
 LogExpFunctions = "0.3"
 MacroTools = "0.5"
 NaNMath = "0.3, 1"
@@ -34,7 +35,8 @@ julia = "1"
 [extras]
 DiffTests = "de460e47-3fe3-5279-bb4a-814414816d5d"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
+IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DiffTests", "FillArrays", "Test"]
+test = ["DiffTests", "FillArrays", "IrrationalConstants", "Test"]

--- a/src/ReverseDiff.jl
+++ b/src/ReverseDiff.jl
@@ -24,7 +24,7 @@ using ChainRulesCore
 # Not all operations will be valid over all of these types, but that's okay; such cases
 # will simply error when they hit the original operation in the overloaded definition.
 const ARRAY_TYPES = (:AbstractArray, :AbstractVector, :AbstractMatrix, :Array, :Vector, :Matrix)
-const REAL_TYPES = (:Bool, :Integer, :(Irrational{:ℯ}), :(Irrational{:π}), :Rational, :BigFloat, :BigInt, :AbstractFloat, :Real, :Dual)
+const REAL_TYPES = (:Bool, :Integer, :AbstractIrrational, :Rational, :BigFloat, :BigInt, :AbstractFloat, :Real, :Dual)
 
 const SKIPPED_UNARY_SCALAR_FUNCS  = Symbol[:isinf, :isnan, :isfinite, :iseven, :isodd, :isreal, :isinteger]
 const SKIPPED_BINARY_SCALAR_FUNCS = Symbol[:isequal, :isless, :<, :>, :(==), :(!=), :(<=), :(>=)]

--- a/test/TrackedTests.jl
+++ b/test/TrackedTests.jl
@@ -4,6 +4,7 @@ using ReverseDiff, Test
 using ReverseDiff: TrackedReal, TrackedArray
 
 import ForwardDiff
+import IrrationalConstants: log2π
 
 include(joinpath(dirname(@__FILE__), "utils.jl"))
 
@@ -609,6 +610,7 @@ empty!(tp)
 @test promote_type(T, Integer) === TrackedReal{BigInt,Float64,A}
 @test promote_type(T, typeof(ℯ)) === TrackedReal{BigFloat,Float64,A}
 @test promote_type(T, typeof(π)) === TrackedReal{BigFloat,Float64,A}
+@test promote_type(T, typeof(log2π)) === TrackedReal{BigFloat,Float64,A}
 @test promote_type(T, Rational{Int}) === TrackedReal{Rational{BigInt},Float64,A}
 @test promote_type(T, BigFloat) === TrackedReal{BigFloat,Float64,A}
 @test promote_type(T, BigInt) === T


### PR DESCRIPTION
Should fix https://github.com/JuliaDiff/ReverseDiff.jl/issues/100. 

Similar to this PR for ForwardDiff: https://github.com/JuliaDiff/ForwardDiff.jl/pull/687